### PR TITLE
Add Github to footer as we are an opensrouce project

### DIFF
--- a/open_humans/templates/pages/about.html
+++ b/open_humans/templates/pages/about.html
@@ -66,10 +66,7 @@
 
 <h3>Staff</h3>
 <p class="bigger-text">
-  In a sense, our "team" is enormous &ndash; the Open Humans community is
-  filled with amazing members, citizen scientists, and researchers that make
-  science something we can all be part of. We're humbled by this! Our formal
-  staff is a small team committed to making this community a success.
+  In a sense, our "team" is enormous &ndash; the Open Humans community is filled with amazing members, citizen scientists, and researchers that make science something we can all be part of. We're humbled by this! Our formal staff is a small team committed to making this community a success.
 </p>
 <div class="staff-list">
   <div class="row">
@@ -79,14 +76,13 @@
         style="max-width:70%">
 
       <h4>Madeleine Price Ball<br>
+        <small>Executive Director<small>
         <small>Co-founder</small>
       </h4>
 
       <p class="staff-text-block">
-        Madeleine wants help connect people and their data to countless research
-        studies. She's a coder, builder, and
-        advocate of knowledge-sharing. She is also PI
-        of the <a href="{% url 'public-data:home' %}">Public Data Sharing study</a>.
+        Madeleine is the Executive Director of the Open Humans Foundation; she wants help connect people and their data to countless research studies.
+        She's a coder, builder, and advocate of knowledge-sharing. She is also the PI of the <a href="{% url 'public-data:home' %}">Public Data Sharing study</a>.
       </p>
     </div>
 
@@ -96,30 +92,13 @@
         style="max-width:70%">
 
       <h4>Jason Bobe<br>
-        <small>Co-founder and Program&nbsp;Director</small>
+        <small>Executive Director Emeritus<small>
+        <small>Co-founder</small>
       </h4>
 
       <p class="staff-text-block">
-         Jason Bobe is the founding Executive Director of the Open Humans
-         Foundation, supporting Open Humans, the Personal Genome Project sites,
-         and leading the annual Genomes, Environment, and Traits conferences.
-         Jason is a steadfast advocate of citizen science, decentralized access
-         to genomic technologies, and DIYbio.</p>
-    </div>
-
-    <div class="col-xs-6 col-sm-4 text-center">
-      <img class="img-circle img-responsive img-center"
-        src="{% static 'images/Hope-Kroog.jpg' %}" alt=""
-        style="max-width:70%">
-
-      <h4>Hope Kroog<br>
-        <small>Resident Layperson</small>
-      </h4>
-
-      <p class="staff-text-block">
-        Hope is fairly new to the world of participatory research. She is
-        enjoying learning about it and helping out in any way she can!
-      </p>
+         Jason Bobe was the initial Executive Director of the Open Humans Foundation, supporting Open Humans, the Personal Genome Project sites, and leading the annual Genomes, Environment, and Traits (GET) conferences.
+         Jason is a steadfast advocate of citizen science, decentralized access to genomic technologies, and DIYbio.</p>
     </div>
   </div>
 </div> <!-- row -->


### PR DESCRIPTION
It is very hard to find the code, and since we are FOSS/OpenSource, I think adding the Github badge with a link to the main organization page made sense.

The only mention is in about, and then still buried.