### PR TITLE
Fix HTTP issue OpenHumans/open-humans#661

### DIFF
--- a/private_sharing/templates/direct-sharing/partials/data-upload.html
+++ b/private_sharing/templates/direct-sharing/partials/data-upload.html
@@ -185,7 +185,7 @@
 echo "test file data" > test-file.txt
 
 TOKEN=example_token
-URL=http://www.openhumans.org/api/project/upload/?access_token=$TOKEN
+URL=https://www.openhumans.org/api/project/upload/?access_token=$TOKEN
 METADATA='{"tags": ["survey", "diet", "csv"], "description": "Diet survey questions and responses", "md5": "156da7fc980988c51682374436849943"}'
 
 http --verbose --form POST $URL \
@@ -419,7 +419,7 @@ project. Note, file extensions are included in the basename.</p>
 #!/bin/sh
 
 TOKEN=example_token
-URL=http://www.openhumans.org/api/project/files/delete/?access_token=$TOKEN
+URL=https://www.openhumans.org/api/project/files/delete/?access_token=$TOKEN
 
 # deleting a file by its ID
 http POST $URL \


### PR DESCRIPTION
There were only two so it was an easy regex
Fix HTTP issue OpenHumans/open-humans#661
---

`public_data/static/docs/Research_Protocol_20141212.pdf` and `public_data/static/docs/Research_Protocol_20160128.pdf`

both still reference `http://` but I am not sure that matters.