### PR TITLE
replace Forum link (closes #668)

### DIFF
--- a/open_humans/templates/member/member-list.html
+++ b/open_humans/templates/member/member-list.html
@@ -20,7 +20,7 @@
 {% if user.is_authenticated %}
 <p class="lead" style="margin-top: 20px;">
   Want to chat with other members?
-  <a href="https://forums.openhumans.org/">Check out our forums!</a>
+  <a href="http://slackin.openhumans.org/">Check out our Slack!</a>
 </p>
 
 <hr>


### PR DESCRIPTION
replace the forum link on `members` with our Slack