### PR TITLE
unapproved projects have member-cap of 20 not 10.

### DIFF
--- a/private_sharing/templates/direct-sharing/partials/about-projects.html
+++ b/private_sharing/templates/direct-sharing/partials/about-projects.html
@@ -61,6 +61,6 @@
 </ul>
 
 <p>
-  Project features work immediately! Up to ten users can join your project,
+  Project features work immediately! Up to twenty users can join your project,
   enabling you to test all features before you're ready to deploy it.
 </p>


### PR DESCRIPTION
fixed the description on `/create`