### PR TITLE
change names, remove public study remnants

### DIFF
--- a/common/activities.py
+++ b/common/activities.py
@@ -306,7 +306,7 @@ def manual_overrides(user, activities):
             'share_data': True,
             'labels': get_labels('share-data', 'academic-non-profit',
                                  'study'),
-            'leader': 'Madeleine Ball',
+            'leader': 'Mad Ball',
             'organization': 'Open Humans Foundation',
             'description': pds_description,
             'long_description': pds_description,

--- a/open_humans/templates/email/welcome.html
+++ b/open_humans/templates/email/welcome.html
@@ -84,7 +84,7 @@
 
 <p>Sincerely,</p>
 
-<p>Madeleine, Jason, and the rest of the Open Humans team.</p>
+<p>Mad, Bastian, and the rest of the Open Humans team.</p>
 
 <p>P.S. You can also follow us on Twitter at <a
     href="https://twitter.com/OpenHumansOrg">@OpenHumansOrg</a>,

--- a/open_humans/templates/email/welcome.txt
+++ b/open_humans/templates/email/welcome.txt
@@ -63,7 +63,7 @@ down data silos in human health and research.
 
 Sincerely,
 
-Madeleine, Jason, and the rest of the Open Humans team.
+Mad, Bastian, and the rest of the Open Humans team.
 
 
 P.S. You can also follow us on Twitter at @OpenHumansOrg,

--- a/open_humans/templates/pages/contact_us.html
+++ b/open_humans/templates/pages/contact_us.html
@@ -54,25 +54,25 @@
       Public data can be a great good for society. In many cases, the data you've
       connected to Open Humans wouldn't otherwise be publicly shared due to privacy
       concerns &ndash; but privacy preferences vary. To learn more,
-      <a href="{% url 'public-data' %}">read about our Public Data Sharing study</a>.
+      <a href="{% url 'public-data:home' %}">read about our Public Data Sharing feature</a>.
     </p>
   </div>
   <div class="col-sm-4 col-xs-11 col-xs-offset-1 col-sm-offset-0">
-    <a class="btn btn-sm btn-default" href="{% url 'direct-sharing:overview' %}">Public Data Sharing study</a>
+    <a class="btn btn-sm btn-default" href="{% url 'public-data:home' %}">Public Data Sharing</a>
   </div>
 </div>
 <div class="row">
   <div class="col-xs-11 col-xs-offset-1">
     <p>
-      For questions and concerns about the Public Data Sharing study, you may
+      For questions and concerns about the Public Data Sharing feature, you may
       contact:
     </p>
     <ul>
-      <li style="margin-bottom:10px;">Study staff at <a
+      <li style="margin-bottom:10px;">Our staff at <a
         href="mailto:support@openhumans.org">support@openhumans.org</a>.</li>
-      <li>The Principal Investigator (Madeleine Ball, PhD) at
-        <a href="mailto:madeleine@openhumans.org">
-          madeleine@openhumans.org</a>.</li>
+      <li>Our Executive Director (Mad Ball, PhD) at
+        <a href="mailto:mad@openhumans.org">
+          mad@openhumans.org</a>.</li>
     </ul>
   </div>
 </div>
@@ -84,7 +84,10 @@
     <p>
       We take security seriously. In addition to ensuring that we use secure methods
       for our website and data, we've developed a set of security guidelines for
-      research partner websites to follow. Read them in full at https://www.openhumans.org/community-guidelines/#study-websites.
+      research partner websites to follow.
+      <a href="https://www.openhumans.org/community-guidelines/#study-websites">
+        You can read them in full.
+      </a>
     </p>
     <p>
       If you've discovered a security issue, please contact us privately at


### PR DESCRIPTION
I found some more remnants that referred to the public data sharing *study* and replaced this with the neutral project. Also removed some old names and replaced them with the appropriate new ones. 