### PR TITLE
Remove link to VCF file in data management page

### DIFF
--- a/activities/vcf_data/templates/vcf_data/manage-files.html
+++ b/activities/vcf_data/templates/vcf_data/manage-files.html
@@ -40,7 +40,7 @@
         <tr>
           <th>Source</th>
           <th>Notes</th>
-          <th>VCF data file</th>
+          <th>VCF file name</th>
           <th></th>
         </tr>
       </thead>
@@ -55,7 +55,7 @@
             {{ vcf_data.additional_notes }}
           </td>
           <td>
-            <a href="{{ vcf_data.vcf_file }}">{{ vcf_data.vcf_file_basename }}</a>
+            {{ vcf_data.vcf_file_basename }}
           </td>
 
           <td>


### PR DESCRIPTION
This is broken, and also redundant with a 'download' link on the
main page for the activity.