### PR TITLE
templates for issue/PR submission

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,21 @@
+<!--- Provide a general description of your issue in the Title above -->
+
+## General Checkups
+- [ ] Have you checked that there isn't already an existing issue that describes what you report below?
+- [ ] Have you checked that there isn't already an open pull requests for this issue/update/change?
+
+<!---
+by the way: if you want to discuss feature requests and bugs with us before submitting anything on GitHub: We're always happy to chat on Slack: http://slackin.openhumans.org/
+ -->
+
+
+## Description
+<!--- Describe your bug/feature request/issue in detail -->
+
+## Related Issue(s)
+<!--- are there other already open issues that relate to this one and
+that interfere with this issue? In that case make sure to mention
+it like "#4" -->
+
+## Example
+<!--- The description above should give a general example of bug you encountered or what feature you would like. This is the place to give a verbose example of what went wrong or what you would like to see improved and how the user-flow would be and how it improves things -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## General Checkups
+- [ ] Have you checked that there aren't other open pull requests for the same issue/update/change?
+- [ ] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?
+
+<!---
+by the way: if you want to discuss feature requests and bugs with us before submitting anything on GitHub: We're always happy to chat on Slack: http://slackin.openhumans.org/
+ -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- if this closes an issue make sure include e.g., "fix #4"
+or similar - or if just relates to an issue make sure to mention
+it like "#4" -->
+
+## Example
+<!--- if introducing a new feature or changing behavior of existing
+methods/functions, include an example if possible to do in brief form -->
+
+<!--- Did you remember to include tests? Unless you're just changing
+grammar, please include new tests for your change -->


### PR DESCRIPTION
I expanded on @BenjaminHCCarr's suggestion (closes #731 and closes #729) by riffing of the templates of `ropensci/taxize`. It makes more use of HTML comments so that people see what is expected in the submissions.