### PR TITLE
[MRG] Refactor API authentication

### DIFF
--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -12,7 +12,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.mixins import NeverCacheMixin
-from common.permissions import HasValidToken
 
 from data_import.utils import get_upload_path
 

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -16,7 +16,8 @@ from common.permissions import HasValidToken
 
 from data_import.utils import get_upload_path
 
-from .api_authentication import ProjectTokenAuthentication
+from .api_authentication import (CustomOAuth2Authentication,
+                                 MasterTokenAuthentication)
 from .api_filter_backends import ProjectFilterBackend
 from .api_permissions import HasValidProjectToken
 from .forms import (DeleteDataFileForm, DirectUploadDataFileForm,
@@ -34,7 +35,8 @@ class ProjectAPIView(NeverCacheMixin):
     The base class for all Project-related API views.
     """
 
-    authentication_classes = (ProjectTokenAuthentication,)
+    authentication_classes = (CustomOAuth2Authentication,
+                              MasterTokenAuthentication)
     permission_classes = (HasValidProjectToken,)
 
     def get_oauth2_member(self):
@@ -82,7 +84,8 @@ class ProjectMemberExchangeView(NeverCacheMixin, RetrieveAPIView):
     Return the project member information attached to the OAuth2 access token.
     """
 
-    permission_classes = (HasValidToken,)
+    authentication_classes = (CustomOAuth2Authentication,)
+    permission_classes = (HasValidProjectToken,)
     serializer_class = ProjectMemberDataSerializer
 
     def get_object(self):
@@ -101,15 +104,11 @@ class ProjectMemberDataView(ProjectListView):
     """
     Return information about the project's members.
     """
-
+    authentication_classes = (MasterTokenAuthentication,)
     serializer_class = ProjectMemberDataSerializer
 
     def get_queryset(self):
-        proj_member = self.get_oauth2_member()
-        if proj_member:
-            return DataRequestProjectMember.objects.filter(id=proj_member.id)
-        else:
-            return DataRequestProjectMember.objects.filter_active()
+        return DataRequestProjectMember.objects.filter_active()
 
 
 class ProjectFormBaseView(ProjectAPIView, APIView):

--- a/private_sharing/templates/direct-sharing/partials/data-upload.html
+++ b/private_sharing/templates/direct-sharing/partials/data-upload.html
@@ -42,14 +42,14 @@
       <li><code>access_token=&lt;{% if on_site_project %}MASTER_{% endif %}ACCESS_TOKEN&gt;</code></li>
     </ul>
 
-    This identifies and authorizes your project.
+    This identifies{% if oauth2_project %} the user{% endif %} and authorizes your project.
   </li>
 
   <li>
     As "multipart/form-data" fields:
 
-    <ul>
-      <li><code>project_member_id</code>: Project member ID (string)</li>
+    <ul>{% if on_site_project %}
+      <li><code>project_member_id</code>: Project member ID (string)</li>{% endif %}
       <li><code>data_file</code>: File</li>
       <li><code>metadata</code>: File metadata (JSON formatted string, see
         below for format)</li>
@@ -188,8 +188,8 @@ TOKEN=example_token
 URL=https://www.openhumans.org/api/direct-sharing/project/upload/?access_token=$TOKEN
 METADATA='{"tags": ["survey", "diet", "csv"], "description": "Diet survey questions and responses", "md5": "156da7fc980988c51682374436849943"}'
 
-http --verbose --form POST $URL \
-  project_member_id='12345678' \
+http --verbose --form POST $URL \{% if on_site_project %}
+  project_member_id='12345678' \{% endif %}
   metadata=$METADATA \
   data_file@./test-file.txt
 </pre>
@@ -206,11 +206,11 @@ Content-Type: multipart/form-data; boundary=60b1416fed664815a28bf8be840458ae
 Host: www.openhumans.org
 User-Agent: HTTPie/0.9.3
 
---60b1416fed664815a28bf8be840458ae
+{% if on_site_project %}--60b1416fed664815a28bf8be840458ae
 Content-Disposition: form-data; name="project_member_id"
 
 12345678
---60b1416fed664815a28bf8be840458ae
+{% endif %}--60b1416fed664815a28bf8be840458ae
 Content-Disposition: form-data; name="metadata"
 
 {"tags": ["survey", "diet", "csv"], "description": "Diet survey questions and responses", "md5": "156da7fc980988c51682374436849943"}
@@ -247,14 +247,14 @@ test file data
       <li><code>access_token=&lt;{% if on_site_project %}MASTER_{% endif %}ACCESS_TOKEN&gt;</code></li>
     </ul>
 
-    This identifies and authorizes your project.
+    This identifies{% if oauth2_project %} the user{% endif %} and authorizes your project.
   </li>
 
   <li>
     As "multipart/form-data" fields:
 
-    <ul>
-      <li><code>project_member_id</code>: Project member ID (string)</li>
+    <ul>{% if on_site_project %}
+      <li><code>project_member_id</code>: Project member ID (string)</li>{% endif %}
       <li><code>filename</code>: The name of the file to upload</li>
       <li><code>metadata</code>: File metadata (JSON formatted string, see
         below for format)</li>
@@ -288,14 +288,14 @@ test file data
       <li><code>access_token=&lt;{% if on_site_project %}MASTER_{% endif %}ACCESS_TOKEN&gt;</code></li>
     </ul>
 
-    This identifies and authorizes your project.
+    This identifies{% if oauth2_project %} the user{% endif %}  and authorizes your project.
   </li>
 
   <li>
     As "multipart/form-data" fields:
 
-    <ul>
-      <li><code>project_member_id</code>: Project member ID (string)</li>
+    <ul>{% if on_site_project %}
+      <li><code>project_member_id</code>: Project member ID (string)</li>{% endif %}
       <li><code>file_id</code>: The ID of the file from the first step</li>
     </ul>
   </li>
@@ -305,16 +305,16 @@ test file data
 
 <pre>
 TOKEN=
-PROJECT_MEMBER_ID=
-
+{% if on_site_project %}PROJECT_MEMBER_ID=
+{% endif %}
 BASE_URL=https://www.openhumans.org
 
 UPLOAD_URL=$BASE_URL/api/direct-sharing/project/files/upload/direct/?access_token=$TOKEN
 COMPLETE_URL=$BASE_URL/api/direct-sharing/project/files/upload/complete/?access_token=$TOKEN
 
 # get a file ID and an upload URL
-JSON=`http --form POST $UPLOAD_URL \
-  project_member_id=$PROJECT_MEMBER_ID \
+JSON=`http --form POST $UPLOAD_URL \{% if on_site_project %}
+  project_member_id=$PROJECT_MEMBER_ID \{% endif %}
   metadata='{"tags": ["survey", "diet", "csv"], "description": "Diet survey questions and responses"}' \
   filename="test-file.json"`
 
@@ -328,8 +328,8 @@ echo '{"testing": "just testing..."}' > test-file.json
 http --verbose PUT "$URL" Content-Type: @./test-file.json
 
 # notify Open Humans that we've completed the upload
-http --verbose --form POST $COMPLETE_URL \
-  project_member_id=$PROJECT_MEMBER_ID \
+http --verbose --form POST $COMPLETE_URL \{% if on_site_project %}
+  project_member_id=$PROJECT_MEMBER_ID \{% endif %}
   file_id=$ID
 </pre>
 
@@ -382,13 +382,14 @@ http --verbose --form POST $COMPLETE_URL \
       </li>
     </ul>
 
-    This identifies and authorizes your project.
+    This identifies{% if oauth2_project %} the user{% endif %} and authorizes your project.
   </li>
 
   <li>
-    A JSON object request body with the project member ID (string), and one the
-    follow items: 'file_id' (integer), 'file_basename' (string), 'all_files'
-    (boolean). See examples below for usage.
+    A JSON object request body with {% if on_site_project %}the project member
+    ID (string), and {% endif %}one the follow items:
+    'file_id' (integer), 'file_basename' (string), 'all_files' (boolean).
+    See examples below for usage.
   </li>
 </ul>
 
@@ -397,20 +398,20 @@ http --verbose --form POST $COMPLETE_URL \
 <p>Delete file ID #12345 for member 12345678 for this project:</p>
 
 <p>
-  <code>{"project_member_id": "12345678", "file_id": 12345}</code>
+  <code>{{% if on_site_project %}"project_member_id": "12345678", {% endif %}"file_id": 12345}</code>
 </p>
 
 <p>Delete any files with the name 'foobar.txt' for member 12345678 for this
 project. Note, file extensions are included in the basename.</p>
 
 <p>
-  <code>{"project_member_id": "12345678", "file_basename": "foobar.txt"}</code>
+  <code>{{% if on_site_project %}"project_member_id": "12345678", {% endif %}"file_basename": "foobar.txt"}</code>
 </p>
 
 <p>Delete all files for project member 12345678 for this project:</p>
 
 <p>
-  <code>{"project_member_id": "12345678", "all_files": True}</code>
+  <code>{% if on_site_project %}{"project_member_id": "12345678", {% endif %}"all_files": True}</code>
 </p>
 
 <h4>Examples for httpie</h4>
@@ -422,18 +423,18 @@ TOKEN=example_token
 URL=https://www.openhumans.org/api/direct-sharing/project/files/delete/?access_token=$TOKEN
 
 # deleting a file by its ID
-http POST $URL \
-  project_member_id='12345678' \
+http POST $URL \{% if on_site_project %}
+  project_member_id='12345678' \{% endif %}
   file_id:=12345
 
 # deleting a file by its name
-http POST $URL \
-  project_member_id='12345678' \
+http POST $URL \{% if on_site_project %}
+  project_member_id='12345678' \{% endif %}
   file_basename='foobar.txt'
 
 # deleting all files for a project member
-http POST $URL \
-  project_member_id='12345678' \
+http POST $URL \{% if on_site_project %}
+  project_member_id='12345678' \{% endif %}
   all_files:=True
 </pre>
 
@@ -449,7 +450,7 @@ Host: www.openhumans.org
 User-Agent: HTTPie/0.9.3
 
 {
-    "file_id": 12345,
-    "project_member_id": "12345678"
+    "file_id": 12345{% if on_site_project %},
+    "project_member_id": "12345678"{% endif %}
 }
 </pre>

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,6 @@ Django==1.9.9
 django-appconf==1.0.2
 django-autoslug==1.9.3
 django-bootstrap-pagination==1.6.1
-django-braces==1.9.0
 django-cors-headers==1.1.0
 django-coverage-plugin==1.3.1
 django-debug-toolbar==1.5
@@ -20,7 +19,7 @@ django-filter==0.14.0
 django-forms-bootstrap==3.0.1
 django-hash-filter==1.1.0
 django-ipware==1.1.5
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit==0.12.0
 django-pylibmc==0.6.1
 django-recaptcha==1.0.5
 django-sslify==0.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ dj-database-url==0.4.1
 django-appconf==1.0.2
 django-autoslug==1.9.3
 django-bootstrap-pagination==1.6.1
-django-braces==1.9.0
+django-braces==1.12.0     # via django-oauth-toolkit
 django-cors-headers==1.1.0
 django-coverage-plugin==1.3.1
 django-debug-toolbar==1.5
@@ -30,7 +30,7 @@ django-forms-bootstrap==3.0.1
 django-gulp==2.4.1
 django-hash-filter==1.1.0
 django-ipware==1.1.5
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit==0.12.0
 django-pylibmc==0.6.1
 django-recaptcha==1.0.5
 django-sslify==0.2.7
@@ -61,7 +61,7 @@ markdown==2.6.6
 markupsafe==1.0           # via jinja2
 mock==2.0.0
 oauth2==1.9.0.post1       # via flask-oauth
-oauthlib==1.0.3           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
+oauthlib==2.0.1           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
 pbr==3.1.1                # via mock
 pillow==3.3.1
 psutil==4.1.0             # via django-gulp
@@ -73,7 +73,7 @@ python-dateutil==2.6.1    # via arrow, faker
 python-magic==0.4.13
 python-openid==2.2.5      # via python-social-auth
 python-social-auth==0.2.21
-pytz==2017.3              # via django-user-accounts
+pytz==2018.3              # via django-user-accounts
 raven==5.24.3
 requests-oauthlib==0.8.0  # via python-social-auth
 requests==2.11.1


### PR DESCRIPTION
## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description

Converting `ProjectTokenAuthentication` to two classes: `MasterTokenAuthentication` and `CustomOAuth2Authentication`. This is meant to clarify the two different types of token authentications, allowing endpoints to use both, or just one.

`MasterTokenAuthentication` behaves as `ProjectTokenAuthentication` previously did, but will no longer authenticate OAuth2 tokens. `CustomOAuth2Authentication` is derived from django-oauth-toolkit's `OAuth2Authentication`, modifying it to (1) raise a more user-friendly error message for expired tokens and (2) return a `(user, project)` tuple that matches the behavior of `MasterTokenAuthentication` (and prior behavior of `ProjectTokenAuthentication`).

`ProjectMemberDataView` is updated to only function for master tokens, matching its originally intended behavior and documentation.

Tests have been added for some issues, including testing that expired OAuth2 tokens will result in an API error. (This wasn't true before, due to a bug in `ProjectTokenAuthentication`'s behavior.)

## Related Issue
Fixes #575

## Example

A call to the "exchange member" viewpoint with an expired token will result in a more useful error message.

```
> req = requests.get(
    '{}/api/direct-sharing/project/exchange-member/?access_token={}'.format(
        base_url, expired_token))
> req.status_code
401
> req.json()
{u'detail': u'Expired token.'}
```