### PR TITLE
Fix stats script to not count suspended users

### DIFF
--- a/open_humans/management/commands/stats_new.py
+++ b/open_humans/management/commands/stats_new.py
@@ -25,7 +25,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         cutoff = arrow.get(options['date']).datetime
 
-        members = Member.objects.filter(user__date_joined__lte=cutoff)
+        members = Member.objects.filter(
+            user__date_joined__lte=cutoff).filter(
+            user__is_active=True)
         members_with_data = members.annotate(
             datafiles_count=Count('user__datafiles')).filter(
             datafiles_count__gte=1)
@@ -38,11 +40,13 @@ class Command(BaseCommand):
             df['source'], df['user__username']) for
             df in DataFile.objects.exclude(
             archived__lte=cutoff).filter(
+            user__is_active=True).filter(
             created__lte=cutoff).values('user__username', 'source')])
 
         proj_connections = DataRequestProjectMember.objects.exclude(
-            project__approved=False).exclude(joined=False).exclude(
-            authorized=False).filter(created__lte=cutoff)
+            project__approved=False).exclude(joined=False).filter(
+            member__user__is_active=True).exclude(authorized=False).filter(
+            created__lte=cutoff)
 
         print("Members: {}".format(members.count()))
         print("Members with any data connections: {}".format(


### PR DESCRIPTION
## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
Bug fix for the `stats_new` script, to filter out suspended accounts from the statistics.