### PR TITLE
[WIP] Transferring legacy 23andme to project

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -6,6 +6,9 @@ from django.apps import apps
 from django.conf import settings
 from django.http import QueryDict
 
+# TODO: Remove legacy apps and this filtering step.
+LEGACY_APPS = ['go_viral', 'twenty_three_and_me']
+
 
 def querydict_from_dict(input_dict):
     """
@@ -39,8 +42,7 @@ def get_source_labels_and_configs():
                app_config.name.startswith('activities.')
                ]
 
-    # TODO: Remove when completing go_viral app removal.
-    sources = [x for x in sources if x[0] != 'go_viral']
+    sources = [x for x in sources if x[0] not in LEGACY_APPS]
 
     return sorted(sources, key=lambda x: x[1].verbose_name.lower())
 

--- a/common/views.py
+++ b/common/views.py
@@ -36,8 +36,12 @@ class BaseOAuth2AuthorizationView(LargePanelMixin, AuthorizationView):
         """
         Get requesting application for custom login-or-signup.
         """
-        return get_oauth2_application_model().objects.get(
-            client_id=self.request.GET.get('client_id'))
+        if self.request.method == 'GET':
+            return get_oauth2_application_model().objects.get(
+                client_id=self.request.GET.get('client_id'))
+        elif self.request.method == 'POST':
+            return get_oauth2_application_model().objects.get(
+                client_id=self.request.POST.get('client_id'))
 
     def dispatch(self, request, *args, **kwargs):
         """

--- a/open_humans/management/commands/move_legacy_to_proj.py
+++ b/open_humans/management/commands/move_legacy_to_proj.py
@@ -1,0 +1,133 @@
+from itertools import groupby
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+
+from data_import.models import DataFile
+from open_humans.models import Member
+from private_sharing.models import (
+    DataRequestProject, DataRequestProjectMember, ProjectDataFile)
+
+
+class Command(BaseCommand):
+    """
+    Transfer a legacy source to an OH-operated project.
+
+    Creates a corresponding project membership, and modifies associated
+    DataFile objects to be associated with this project.
+
+    ID and slug of the target project are both requested in input to reduce
+    the chance of accidentally transfering to an incorrect project.
+
+    This function is written generically because it may be re-used in the
+    future, but it needs to be tested with each app! self.ALLOWED_APPS reflects
+    this; modify this only after testing.
+    """
+
+    ALLOWED_APPS = ['twenty_three_and_me']
+    help = 'Transfer a legacy source to a project'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--legacy', type=str,
+                            help='label of legacy source to be transferred')
+        parser.add_argument('--proj-id', type=str,
+                            help='ID of project to transfer to')
+        parser.add_argument('--proj-slug', type=str,
+                            help='Slug of project to transfer to')
+        parser.add_argument('--userdata-field-clean',
+                            help='Set this legacy UserData field to None')
+        parser.add_argument('--user', type=str,
+                            help='Transfer just a specific user by username')
+        parser.add_argument('--all-users', action='store_true',
+                            help='Run for all users')
+
+    def handle(self, *args, **options):
+        proj_id = options['proj_id']
+        proj_slug = options['proj_slug']
+        legacy_source = options['legacy']
+        userdata_field_clean = options['userdata_field_clean']
+        username = options['user']
+        all_users = options['all_users']
+
+        if username and all_users:
+            raise ValueError('Either specify a user or all-users, not both!')
+
+        project = self._get_proj(
+            proj_id=proj_id, proj_slug=proj_slug)
+        legacy_config, legacy_files_by_uid = self._get_legacy(
+            legacy_source=legacy_source)
+
+        if username:
+            uid_list = [Member.objects.get(user__username=username).user.id]
+        elif all_users:
+            uid_list = sorted(legacy_files_by_uid.keys())
+        else:
+            uid_list = []
+
+        for uid in uid_list:
+            project_member = self._create_projmember(project=project, uid=uid)
+            print('Transferring {}...'.format(
+                project_member.member.user.username))
+            legacy_userdata = legacy_config.models[
+                'userdata'].objects.get(user__id=uid)
+            if userdata_field_clean:
+                setattr(legacy_userdata, userdata_field_clean, None)
+                legacy_userdata.save()
+            for df in legacy_files_by_uid[uid]:
+                df.source = project.id_label
+                df.save()
+                self._create_projdatafile(df, project_member)
+            print('Transferred {}'.format(project_member.member.user.username))
+
+    def _get_proj(self, proj_id, proj_slug):
+        project = DataRequestProject.objects.get(id=proj_id)
+        if proj_slug != project.slug:
+            raise ValueError("Project ID ({}) and slug ({}) don't "
+                             'match!'.format(proj_id, proj_slug))
+        return project
+
+    def _get_legacy(self, legacy_source):
+        if legacy_source not in self.ALLOWED_APPS:
+            raise ValueError('App label "{}" not in ALLOWED_APPS!'.format(
+                legacy_source))
+
+        legacy_config = apps.get_app_config(legacy_source)
+
+        legacy_files_by_uid = {
+            key: [r for r in result] for key, result in groupby(
+                DataFile.objects.filter(source=legacy_source).current(),
+                key=lambda x: x.user.id)}
+
+        return legacy_config, legacy_files_by_uid
+
+    def _create_projmember(self, project, uid):
+        member = Member.objects.get(user__id=uid)
+        project_member, _ = DataRequestProjectMember.objects.get_or_create(
+            member=member,
+            project=project)
+        if project.type == 'oauth2':
+            project_member.joined = True
+
+        project_member.authorized = True
+        project_member.revoked = False
+        project_member.message_permission = project.request_message_permission
+        project_member.username_shared = project.request_username_access
+        project_member.sources_shared = project.request_sources_access
+        project_member.all_sources_shared = project.all_sources_access
+        project_member.save()
+
+        return project_member
+
+    def _create_projdatafile(self, df, proj_member):
+        pdf = ProjectDataFile(
+            completed=True,
+            parent=df,
+            direct_sharing_project=proj_member.project,
+            user=proj_member.member.user,
+            source=df.source,
+            archived=df.archived,
+            created=df.created,
+            metadata=df.metadata,
+            file=df.file)
+        pdf.save()
+        return pdf

--- a/open_humans/management/commands/move_legacy_to_proj.py
+++ b/open_humans/management/commands/move_legacy_to_proj.py
@@ -44,8 +44,6 @@ class Command(BaseCommand):
                             help='Slug of project to transfer to')
         parser.add_argument('--base-url', type=str,
                             help='Base URL to send OAuth2 request')
-        parser.add_argument('--userdata-field-clean',
-                            help='Set this legacy UserData field to None')
         parser.add_argument('--user', type=str,
                             help='Transfer just a specific user by username')
         parser.add_argument('--all-users', action='store_true',
@@ -56,7 +54,6 @@ class Command(BaseCommand):
         proj_id = options['proj_id']
         proj_slug = options['proj_slug']
         legacy_source = options['legacy']
-        userdata_field_clean = options['userdata_field_clean']
         username = options['user']
         all_users = options['all_users']
 
@@ -79,11 +76,6 @@ class Command(BaseCommand):
             project_member = self._create_projmember(project=project, uid=uid)
             print('Transferring {}...'.format(
                 project_member.member.user.username))
-            legacy_userdata = legacy_config.models[
-                'userdata'].objects.get(user__id=uid)
-            if userdata_field_clean:
-                setattr(legacy_userdata, userdata_field_clean, None)
-                legacy_userdata.save()
             if uid in legacy_files_by_uid:
                 for df in legacy_files_by_uid[uid]:
                     df.source = project.id_label

--- a/open_humans/models.py
+++ b/open_humans/models.py
@@ -16,6 +16,8 @@ from django.db.models import Prefetch, Q
 from oauth2_provider.models import AccessToken
 import requests
 
+from common.utils import LEGACY_APPS
+
 from .storage import PublicStorage
 from .testing import has_migration
 
@@ -193,8 +195,8 @@ class Member(models.Model):
             if not connection_type:
                 continue
 
-            # TODO: Remove this when completing go_viral app removal.
-            if app_config.label == 'go_viral':
+            # TODO: Remove this when completing app removal.
+            if app_config.label in LEGACY_APPS:
                 continue
 
             # all of the is_connected methods are written in a way that they


### PR DESCRIPTION
## Description
Creates a management command that transfers the legacy 23andMe upload to a project model, making the user a member of this project, transferring files, and generating tokens.

## Related Issue
Towards completing #745, this addresses token creation and file transfer tasks.

## Example
The `--all-users` command can be used to iterate through all users. This single user alternative just transfers a target user:
`python manage.py move_legacy_to_proj --legacy twenty_three_and_me --proj-id 128 --proj-slug 23andme-upload --userdata-field-clean=genome_file --user madprime --base-url http://127.0.0.1:8000/`