### PR TITLE
Fix image path issue for grant project images

### DIFF
--- a/open_humans/models.py
+++ b/open_humans/models.py
@@ -32,7 +32,7 @@ def get_grant_project_image_upload_path(instance, filename):
     """
     Construct the upload path for an image for a ProjectGrant object.
     """
-    return '/grant-projects/%s/%s' % (instance.name, filename)
+    return 'grant-projects/%s/%s' % (instance.name, filename)
 
 def random_member_id():
     """

--- a/open_humans/models.py
+++ b/open_humans/models.py
@@ -28,6 +28,11 @@ def get_member_profile_image_upload_path(instance, filename):
     """
     return 'member/%s/profile-images/%s' % (instance.user.id, filename)
 
+def get_grant_project_image_upload_path(instance, filename):
+    """
+    Construct the upload path for an image for a ProjectGrant object.
+    """
+    return '/grant-projects/%s/%s' % (instance.name, filename)
 
 def random_member_id():
     """
@@ -272,7 +277,7 @@ class GrantProject(models.Model):
         max_length=1024,
         # Stored on S3
         storage=PublicStorage(),
-        upload_to=get_member_profile_image_upload_path)
+        upload_to=get_grant_project_image_upload_path)
     blog_url = models.TextField()
     project_desc = models.TextField()
 


### PR DESCRIPTION
## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
When #787 was merged it used the function `get_member_profile_image_upload_path` which looks for `instance.user` and will produce an error because the model `GrantProject` does **not** contain a user. 

There are semi-generic path generators for data files in `data_import`, but I think that it's more verbose to add a new function that generates paths specifically for grant project images, `get_grant_project_image_upload_path`, under the path `/grant-projects/<grant_project_name>/<filename>`. Grant project names are `unique=True` in the models, so we don't risk clashing URL namespaces for multiple projects.

This PR updates the `GrantProject` model to use the new image upload path generator rather than the old one, which requires a relational user object.