### PR TITLE
add url_slug for public data

### DIFF
--- a/common/activities.py
+++ b/common/activities.py
@@ -240,7 +240,7 @@ def public_data_activity(user):
         'type': 'internal',
         'connect_verb': 'join',
         'join_url': reverse('public-data:home'),
-        'url_slug': None,
+        'url_slug': reverse('public-data:home'),
         'is_connected': (user and
                          user.member.public_data_participant.enrolled),
         'members': badge_counts().get('public_data_sharing', 0),

--- a/public_data/apps.py
+++ b/public_data/apps.py
@@ -8,8 +8,6 @@ class PublicDataConfig(AppConfig):
 
     name = 'public_data'
     verbose_name = 'Public Data'
-    
-    url_slug = 'public-data'
 
     def ready(self):
         # Make sure our signal handlers get hooked up

--- a/public_data/apps.py
+++ b/public_data/apps.py
@@ -8,6 +8,8 @@ class PublicDataConfig(AppConfig):
 
     name = 'public_data'
     verbose_name = 'Public Data'
+    
+    url_slug = 'public-data'
 
     def ready(self):
         # Make sure our signal handlers get hooked up


### PR DESCRIPTION
This had been returning "NONE" the fallthrough in the python script. I believe this should close #798

You might want to test this on staging, but given that it fails in current state...

This was based on the `url_slug` in the `apps.py` of ancestry_dna page.

## General Checkups
- [X] Have you checked that there aren't other open pull requests for the same issue/update/change?


## Related Issue
fix #798
