### PR TITLE
prevent activity stream duplicates

### DIFF
--- a/private_sharing/views.py
+++ b/private_sharing/views.py
@@ -91,7 +91,10 @@ class ProjectMemberMixin(object):
         django_messages.success(self.request, (
             'You have successfully joined the project "{}".'.format(
                 project.name)))
-        if project.approved:
+        if project.approved and not ActivityFeed.objects.filter(
+           member=self.project_member.member,
+           project=project,
+           action='joined-project').exists():
             event = ActivityFeed(
                 member=self.project_member.member,
                 project=project,

--- a/private_sharing/views.py
+++ b/private_sharing/views.py
@@ -92,9 +92,9 @@ class ProjectMemberMixin(object):
             'You have successfully joined the project "{}".'.format(
                 project.name)))
         if project.approved and not ActivityFeed.objects.filter(
-           member=self.project_member.member,
-           project=project,
-           action='joined-project').exists():
+                member=self.project_member.member,
+                project=project,
+                action='joined-project').exists():
             event = ActivityFeed(
                 member=self.project_member.member,
                 project=project,

--- a/public_data/views.py
+++ b/public_data/views.py
@@ -136,8 +136,8 @@ class ToggleSharingView(PrivateMixin, RedirectView):
                 project = DataRequestProject.objects.get(
                     id=int(match.group('id')))
                 if project.approved and not ActivityFeed.objects.filter(
-                   member=user.member, project=project,
-                   action='publicly-shared').exists():
+                        member=user.member, project=project,
+                        action='publicly-shared').exists():
                     event = ActivityFeed(
                         member=user.member,
                         project=project,

--- a/public_data/views.py
+++ b/public_data/views.py
@@ -135,7 +135,10 @@ class ToggleSharingView(PrivateMixin, RedirectView):
             if match:
                 project = DataRequestProject.objects.get(
                     id=int(match.group('id')))
-                if project.approved:
+                if project.approved and not ActivityFeed.objects.filter(
+                   member=user.member,
+                   project=project,
+                   action='publicly-shared').exists():
                     event = ActivityFeed(
                         member=user.member,
                         project=project,

--- a/public_data/views.py
+++ b/public_data/views.py
@@ -136,8 +136,7 @@ class ToggleSharingView(PrivateMixin, RedirectView):
                 project = DataRequestProject.objects.get(
                     id=int(match.group('id')))
                 if project.approved and not ActivityFeed.objects.filter(
-                   member=user.member,
-                   project=project,
+                   member=user.member, project=project,
                    action='publicly-shared').exists():
                     event = ActivityFeed(
                         member=user.member,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

<!---
by the way: if you want to discuss feature requests and bugs with us before submitting anything on GitHub: We're always happy to chat on Slack: http://slackin.openhumans.org/
 -->

## Description
<!--- Describe your changes in detail -->
The activity stream would show duplicate entries for re-joining a project a member was already a member of but where the external project would require new oauth credentials and similarly when data was being made public a 'second time'. These could look weird on the frontend. 

This PR would fix these by not adding a second item to the stream if people have already done the action once.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Closes #801
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
