### PR TITLE
Make GitHub recognize the LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,13 @@
-open-humans
+MIT License
 
-Copyright (C) 2014-2016 Open Humans Foundation
+Copyright (c) 2014-2018 Open Humans Foundation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
GitHub should display MIT badge in top right corner if license is recognized.

![image](https://user-images.githubusercontent.com/8781107/42877325-da382984-8abb-11e8-835e-c2bc5ff627e8.png)

Current page shows this.

![image](https://user-images.githubusercontent.com/8781107/42877465-507c5cdc-8abc-11e8-9082-723ac1fc4d7d.png)

Even if this PR doesn't change license text much, it is still able to kick the GitHub license match job.

As a benefit, this project could be then filtered by MIT License.