### PR TITLE
hotfix for missing projects on add/explore pages

### DIFF
--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -289,6 +289,11 @@ class AddDataPageView(NeverCacheMixin, SourcesContextMixin, TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super(AddDataPageView,
                         self).get_context_data(*args, **kwargs)
+        # This returns all approved & active projects in the context
+        # The filtering to only get data-adding projects
+        # is done later in the template.
+        # TODO: Will be overhauled with Issue #809 to make this less
+        # convoluted
         projects = DataRequestProject.objects.filter(
             approved=True).filter(
             active=True)

--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -289,9 +289,7 @@ class AddDataPageView(NeverCacheMixin, SourcesContextMixin, TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super(AddDataPageView,
                         self).get_context_data(*args, **kwargs)
-        projects = DataRequestProject.objects.exclude(
-            returned_data_description__isnull=True).exclude(
-            returned_data_description='').filter(
+        projects = DataRequestProject.objects.filter(
             approved=True).filter(
             active=True)
         print(projects.count())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?

<!---
by the way: if you want to discuss feature requests and bugs with us before submitting anything on GitHub: We're always happy to chat on Slack: http://slackin.openhumans.org/
 -->

## Description
<!--- Describe your changes in detail -->
This is a hotfix for #809, it does not solve the general overhaul for the pages, but at least all projects are listed again. The solution was rather easy, as we just did a wrong filtering in the general class. 

## Related Issue
#809 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

![screen shot 2018-08-16 at 12 04 47](https://user-images.githubusercontent.com/674899/44229470-05672680-a14d-11e8-8499-08492931fb94.png)

This is how the `Explore Data` tab will look like with the change made, compare to the current view at https://www.openhumans.org/explore-share/ that currently only lists 5(!) projects.