### PR TITLE
Re-enable some of the API tests

### DIFF
--- a/open_humans/fixtures/test-data.json
+++ b/open_humans/fixtures/test-data.json
@@ -177,6 +177,18 @@
     }
 },
 {
+    "model": "account.emailaddress",
+    "pk": 1,
+    "fields": {
+      "user": [
+        "bacon"
+      ],
+      "email": "bacon@example.com",
+      "verified": true,
+      "primary": true
+    }
+},
+{
     "model": "data_import.datafile",
     "pk": 1,
     "fields": {
@@ -198,21 +210,39 @@
     "model": "data_import.datafile",
     "pk": 2,
     "fields": {
-      "file": "member-files/direct-sharing-1/eb836cde-9fe3-11e8-9f55-0242c0a80002/trance1.json",
+      "file": "member-files/direct-sharing-2/eb836cde-9fe3-11e8-9f55-0242c0a80002/chiptune0.json",
       "metadata": {
-          "description": "Trance songs I like",
+          "description": "Chiptune songs I like",
           "tags": [
-              "trance",
+              "chiptune",
               "music",
-              "is groovy"
+              "is synthetic"
               ]
       },
       "created": "2018-08-14 17:03:09.250196+00",
-      "source": "direct-sharing-1",
+      "source": "direct-sharing-2",
       "user_id": 1
     }
 },
-  {
+{
+    "model": "data_import.datafile",
+    "pk": 3,
+    "fields": {
+      "file": "member-files/direct-sharing-2/38756cde-9fe0-11e8-9f55-0242c0a80002/glitch0.json",
+      "metadata": {
+          "description": "Glitch songs I like",
+          "tags": [
+              "glitch",
+              "music",
+              "is weird"
+              ]
+      },
+      "created": "2018-08-14 17:03:09.250196+00",
+      "source": "direct-sharing-3",
+      "user_id": 1
+    }
+},
+{
     "model": "oauth2_provider.application",
     "pk": 1,
     "fields": {

--- a/private_sharing/api_authentication.py
+++ b/private_sharing/api_authentication.py
@@ -20,6 +20,7 @@ class MasterTokenAuthentication(BaseAuthentication):
     """
 
     def authenticate(self, request):
+        request.oauth2_error = getattr(request, 'oauth2_error', {})
         auth = get_authorization_header(request).split()
         if not auth or auth[0].lower() != b'bearer':
             return None
@@ -82,6 +83,7 @@ class CustomOAuth2Authentication(OAuth2Authentication):
         Raises an exception for an expired token, or returns two-tuple of
         (user, project) if authentication succeeds, or None otherwise.
         """
+        request.oauth2_error = getattr(request, 'oauth2_error', {})
         access_token = None
         try:
             auth = get_authorization_header(request).split()

--- a/private_sharing/fixtures/test-data.json
+++ b/private_sharing/fixtures/test-data.json
@@ -15,7 +15,7 @@
     "long_description": "def",
     "active": true,
     "badge_image": "",
-    "request_sources_access": "[\"direct-sharing-128\", \"direct-sharing-134\", \"direct-sharing-129\", \"direct-sharing-133\"]",
+    "request_sources_access": "[\"direct-sharing-2\"]",
     "request_message_permission": true,
     "request_username_access": true,
     "returned_data_description": "abc",

--- a/private_sharing/testing.py
+++ b/private_sharing/testing.py
@@ -1,4 +1,7 @@
 from io import StringIO
+from unittest import skipIf
+
+from django.conf import settings
 
 from common.testing import SmokeTestCase
 
@@ -51,6 +54,7 @@ class DirectSharingMixin(object):
 
 class DirectSharingTestsMixin(object):
 
+    @skipIf((not settings.AWS_STORAGE_BUCKET_NAME), 'AWS bucket not set up.')
     def test_file_upload(self):
         member = self.update_member(joined=True, authorized=True)
 
@@ -217,6 +221,7 @@ class DirectSharingTestsMixin(object):
 
         self.assertEqual(response.status_code, 400)
 
+    @skipIf((not settings.AWS_STORAGE_BUCKET_NAME), 'AWS bucket not set up.')
     def test_direct_upload(self):
         member = self.update_member(joined=True, authorized=True)
 


### PR DESCRIPTION
## General Checkups
- [x] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [x] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
Reenables some of the API tests.

To re-enable these, there's...
1. some updates to test data (datafiles and project) for testing purposes
2. adding an EmailAddress entry to test data, from django-user-accounts, for one of the test users
3. an update to our custom API authentication which I think may be accounting for some new behavior in django-rest-framework and/or django-oauth-toolkit that was introduced in the Django 2 upgrades

Also added a `unittest.skipIf` to skip tests that will break if an AWS S3 bucket isn't set up. The files in test data aren't actually present in the bucket/credentials I tested with, but the tests seem to be passing for me.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
