### PR TITLE
Add note about messaging prior to removal

### DIFF
--- a/private_sharing/templates/direct-sharing/partials/member-removal.html
+++ b/private_sharing/templates/direct-sharing/partials/member-removal.html
@@ -17,6 +17,10 @@
   Removal does not prevent a member from re-joining a project.
 </p>
 
+<p>
+  <b>Note:</b> If you plan to message members to inform them of their removal, you must do so before removing them. You will be unable to message them after the removal, as they will no longer be members.
+</p>
+
 <h3 id="via-form">Removing via website form</h3>
 
 <ol>


### PR DESCRIPTION
## Description
Making note about making sure to message members (if desired) before doing the removal, as project admin won't be able to message afterward.

Comment -  I am working on a template message for this to use. Would you like me to add a link to it here, or include it here? Can either include it on this page, or maybe link to it and store it on the wiki? (The latter might be my preference so it's easy for others to improve it directly in the wiki more quickly?)