### PR TITLE
Fix filtering members list on project

### DIFF
--- a/open_humans/member_views.py
+++ b/open_humans/member_views.py
@@ -6,8 +6,9 @@ import arrow
 
 from django.apps import apps
 from django.contrib import messages as django_messages
-from django.urls import reverse, reverse_lazy
+from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
+from django.urls import reverse, reverse_lazy
 from django.utils.safestring import mark_safe
 from django.views.generic.base import RedirectView, TemplateView, View
 from django.views.generic.detail import DetailView, SingleObjectMixin
@@ -89,7 +90,12 @@ class MemberListView(ListView):
                 raise Http404()
 
             project = id_label_to_project(filter_name)
-            queryset = queryset.filter(datarequestproject=project)
+            project_members = Q(datarequestprojectmember__project=project)
+            authorized_members = Q(datarequestprojectmember__authorized=True)
+            visible_members = Q(datarequestprojectmember__visible=True)
+            not_revoked = Q(datarequestprojectmember__revoked=False)
+            queryset = queryset.filter(project_members & authorized_members &
+                                       visible_members & not_revoked)
 
         projects = self.get_projects()
         sorted_members = queryset.order_by('-id')

--- a/open_humans/member_views.py
+++ b/open_humans/member_views.py
@@ -23,7 +23,8 @@ from common.utils import get_activities, get_studies
 
 from data_import.models import DataFile
 from private_sharing.models import (DataRequestProjectMember,
-                                    app_label_to_verbose_name_including_dynamic)
+                                    app_label_to_verbose_name_including_dynamic,
+                                    id_label_to_project)
 
 from .forms import (EmailUserForm,
                     MemberChangeNameForm,
@@ -87,8 +88,8 @@ class MemberListView(ListView):
             if not badge_exists:
                 raise Http404()
 
-            queryset = queryset.filter(
-                badges__contains=[{'label': filter_name}])
+            project = id_label_to_project(filter_name)
+            queryset = queryset.filter(datarequestproject=project)
 
         projects = self.get_projects()
         sorted_members = queryset.order_by('-id')


### PR DESCRIPTION
## General Checkups
- [*] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [*] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
Filtering members list by project was still trying to use the old (pre-badgectomy) code.  This fixes that.

## Related Issue
857


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>