### PR TITLE
Only show visible/hide button if logged in

### DIFF
--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -458,8 +458,11 @@ class ActivityManagementView(NeverCacheMixin, LargePanelMixin, TemplateView):
                     in ['share_username', 'send_messages', 'share_sources',
                         'all_sources']]))
 
-        show_toggle_visible_button = ((not project_member.revoked) and
-                                      project_member.authorized)
+        if self.request.user.is_authenticated:
+            show_toggle_visible_button = ((not project_member.revoked) and
+                                          project_member.authorized)
+        else:
+            show_toggle_visible_button = False
 
         context.update({
             'activity': self.activity,


### PR DESCRIPTION
If we're not logged in, the activity page errors.  There's no point in showing the membership visibility button if we're not logged in, so don't display it.

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>