### PR TITLE
WIP Replace django-user-accounts with django-allauth

### DIFF
--- a/open_humans/forms.py
+++ b/open_humans/forms.py
@@ -4,7 +4,7 @@ from allauth.account.forms import (
     AddEmailForm,
     ChangePasswordForm as AccountChangePasswordForm,
     LoginForm,
-    ResetPasswordForm as AccountPasswordResetTokenForm,
+    ResetPasswordKeyForm,
     SignupForm)
 from allauth.account.utils import (user_email, user_username)
 
@@ -136,13 +136,36 @@ class ChangePasswordForm(AccountChangePasswordForm):
         return _clean_password(ChangePasswordForm, self, 'password_new')
 
 
-class PasswordResetTokenForm(AccountPasswordResetTokenForm):
+class PasswordResetForm(forms.Form):
     """
     A subclass of account's PasswordResetTokenForm that checks password length.
     """
 
+    password = forms.CharField(
+        label="New Password",
+        widget=forms.PasswordInput(render_value=False))
+    password_confirm = forms.CharField(
+        label="New Password (again)",
+        widget=forms.PasswordInput(render_value=False))
+
+    def clean(self):
+        super().clean()
+        if self._errors:
+            return
+
+        if 'password' in self.cleaned_data \
+           and 'password_confirm' in self.cleaned_data:
+            if self.cleaned_data['password'] \
+               != self.cleaned_data['password_confirm']:
+                self.add_error(
+                    'password_confirm',
+                    'You must type the same password each time.')
+
+        return self.cleaned_data
+
+
     def clean_password(self):
-        return _clean_password(PasswordResetTokenForm, self, 'password')
+        return _clean_password(PasswordResetForm, self, 'password')
 
 
 class MemberProfileEditForm(forms.ModelForm):

--- a/open_humans/models.py
+++ b/open_humans/models.py
@@ -3,7 +3,7 @@ import random
 from collections import OrderedDict
 
 import arrow
-from account.models import EmailAddress as AccountEmailAddress
+from allauth.account.models import EmailAddress as AccountEmailAddress
 from bs4 import BeautifulSoup
 
 from django.apps import apps

--- a/open_humans/settings.py
+++ b/open_humans/settings.py
@@ -35,6 +35,7 @@ class FakeSite(object):
 
     def __init__(self, domain):
         self.domain = domain
+        self.pk = 1
 
     def __str__(self):
         return self.name
@@ -184,27 +185,6 @@ ADMINS = ()
 INSTALLED_APPS = (
     'open_humans',
 
-    # Studies
-    #'studies',
-    #'studies.american_gut',
-    #'studies.go_viral',
-    #'studies.pgp',
-    #'studies.wildlife',
-
-    # Activities
-    #'activities',
-    #'activities.data_selfie',
-    #'activities.fitbit',
-    #'activities.jawbone',
-    #'activities.moves',
-    #'activities.mpower',
-    #'activities.runkeeper',
-    #'activities.withings',
-    #'activities.twenty_three_and_me',
-    #'activities.ancestry_dna',
-    #'activities.ubiome',
-    #'activities.vcf_data',
-
     # Other local apps
     'data_import',
     'private_sharing',
@@ -224,7 +204,9 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     # Third-party modules
-    'account',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
     'bootstrap_pagination',
     'captcha',
     'corsheaders',
@@ -269,15 +251,11 @@ MIDDLEWARE = (
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'account.middleware.LocaleMiddleware',
-    'account.middleware.TimezoneMiddleware',
     'open_humans.middleware.AddMemberMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 template_context_processors = [
-    'account.context_processors.account',
-
     'django.template.context_processors.request',
 
     'django.contrib.auth.context_processors.auth',
@@ -291,6 +269,7 @@ template_context_processors = [
     'django.contrib.messages.context_processors.messages',
 ]
 
+
 template_loaders = [
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
@@ -301,12 +280,6 @@ if not DEBUG and not DISABLE_CACHING:
     template_loaders = [
         ('django.template.loaders.cached.Loader', template_loaders)
     ]
-
-template_options = {
-    'context_processors': template_context_processors,
-    'debug': DEBUG,
-    'loaders': template_loaders,
-}
 
 NOBROWSER = to_bool('NOBROWSER', 'false')
 
@@ -320,14 +293,13 @@ if TESTING:
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'OPTIONS': template_options,
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': template_context_processors,
+            'debug': DEBUG,
+            },
     },
-    # {
-    #     'BACKEND': 'django.template.backends.jinja2.Jinja2',
-    #     'OPTIONS': {
-    #         'loader': template_loaders
-    #     },
-    # },
 ]
 
 ROOT_URLCONF = 'open_humans.urls'
@@ -450,6 +422,7 @@ REST_FRAMEWORK = {
 AUTHENTICATION_BACKENDS = (
     'oauth2_provider.backends.OAuth2Backend',
     'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
 )
 
 GO_VIRAL_MANAGEMENT_TOKEN = os.getenv('GO_VIRAL_MANAGEMENT_TOKEN')

--- a/open_humans/signals.py
+++ b/open_humans/signals.py
@@ -3,7 +3,7 @@ import logging
 import mailchimp
 import requests
 
-from account.signals import email_confirmed
+from allauth.account.signals import email_confirmed
 
 from django.conf import settings
 from django.core.mail import send_mail

--- a/open_humans/templates/account/login-form.html
+++ b/open_humans/templates/account/login-form.html
@@ -18,12 +18,12 @@
   {% endif %}
 
   <div class="form-group{% if form.username.errors %} has-error{% endif %}">
-    <label for="login-username"
+    <label for="login"
       class="col-sm-4 control-label">Username or Email</label>
 
     <div class="col-sm-8">
-      <input type="text" class="form-control" name="username"
-        id="login-username" placeholder="Username"
+      <input type="text" class="form-control" name="login"
+        id="login" placeholder="Username"
         value="{{ form.username.value|default:'' }}">
         {% if form.username.errors %}
           {% for error in form.username.errors %}

--- a/open_humans/templates/account/login-modal.html
+++ b/open_humans/templates/account/login-modal.html
@@ -23,7 +23,7 @@
 
       <div class="modal-footer">
         <div class="text-center small">
-          <a href="{% url 'account_password_reset' %}">Reset&nbsp;password</a>
+          <a href="{% url 'account_reset_password' %}">Reset&nbsp;password</a>
           |
           <a href="{% url 'account_signup' %}" data-dismiss="modal"
             class="signup-link">Create&nbsp;account</a>

--- a/open_humans/templates/account/login.html
+++ b/open_humans/templates/account/login.html
@@ -2,7 +2,10 @@
 
 {% load utilities %}
 
-{% block head_title %}Log in to Open Humans{% endblock %}
+{% load i18n %}
+{% load account socialaccount %}
+
+{% block head_title %}{% trans "Log in to Open Humans" %}{% endblock %}
 {% block head_title_suffix %}{% endblock %}
 
 {% block panel_content %}
@@ -24,7 +27,7 @@
 
   <div class="col-xs-12 text-center small">
     <p>
-      <a href="{% url 'account_password_reset' %}">Reset&nbsp;password</a>
+      <a href="{% url 'account_reset_password' %}">Reset&nbsp;password</a>
       |
       <a href="{% url 'account_signup' %}?next={% next_page %}"
         class="signup-link">Create&nbsp;account</a>

--- a/open_humans/templates/account/password_reset.html
+++ b/open_humans/templates/account/password_reset.html
@@ -17,7 +17,7 @@
       </p>
 
       <form class="form-horizontal" role="form" method="POST"
-        action="{% url 'account_password_reset' %}" id="password-reset-form">
+        action="{% url 'account_reset_password' %}" id="password-reset-form">
         {% csrf_token %}
 
         <input type="hidden" name="next" value="{% next_page %}">

--- a/open_humans/templates/account/password_reset.html
+++ b/open_humans/templates/account/password_reset.html
@@ -2,6 +2,7 @@
 
 {% load bootstrap_tags %}
 {% load utilities %}
+{% load i18n %}
 
 {% block head_title %}Reset your Open Humans password{% endblock %}
 {% block head_title_suffix %}{% endblock %}
@@ -12,8 +13,7 @@
     <div class="col-xs-12">
       {{ form.non_field_errors }}
       <p>
-        Forgot your password? Enter your email address below, and we'll send you
-        an email allowing you to reset it.
+        {% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}
       </p>
 
       <form class="form-horizontal" role="form" method="POST"

--- a/open_humans/templates/account/password_reset_token.html
+++ b/open_humans/templates/account/password_reset_token.html
@@ -14,7 +14,7 @@
     </p>
 
     <form class="form-horizontal" role="form" method="POST"
-      action="{% url 'account_password_reset_token' uidb36=uidb36 token=token %}"
+      action="{{ action_url }}"
       id="password-reset-token-form">
       {% csrf_token %}
 

--- a/open_humans/templates/account/password_reset_token_fail.html
+++ b/open_humans/templates/account/password_reset_token_fail.html
@@ -7,7 +7,7 @@
 {% block panel_content %}
 <div class="row">
   <div class="col-xs-12">
-    {% url "account_password_reset" as url %}
+    {% url "account_reset_password" as url %}
 
     <p>
       The password reset link was invalid, possibly because it has already been

--- a/open_humans/templates/account/signup-form.html
+++ b/open_humans/templates/account/signup-form.html
@@ -97,7 +97,7 @@
     <label for="signup-password" class="col-sm-4 control-label">Password</label>
 
     <div class="col-sm-8">
-      <input type="password" class="form-control" name="password"
+      <input type="password" class="form-control" name="password1"
         id="signup-password" placeholder="Password"
         value="{{ form.password.value|default:'' }}"
         minlength="6" required>
@@ -116,7 +116,7 @@
     </label>
 
     <div class="col-sm-8">
-      <input type="password" class="form-control" name="password_confirm"
+      <input type="password" class="form-control" name="password2"
         id="signup-password-confirm" placeholder="Password"
         value="{{ form.password_confirm.value|default:'' }}"
         data-parsley-equalto="#signup-password" required>

--- a/open_humans/urls.py
+++ b/open_humans/urls.py
@@ -1,5 +1,6 @@
-from allauth.account.views import PasswordChangeView as ChangePasswordView
-from allauth.account.views import PasswordResetView
+from allauth.account.views import (PasswordChangeView as ChangePasswordView,
+                                   PasswordResetFromKeyView,
+                                   PasswordResetView)
 
 from django.conf import settings
 from django.urls import include, path, re_path
@@ -15,7 +16,7 @@ import private_sharing.urls
 import public_data.urls
 
 from . import account_views, api_urls, views, member_views
-from .forms import ChangePasswordForm, PasswordResetTokenForm
+from .forms import ChangePasswordForm
 
 handler500 = 'open_humans.views.server_error'
 
@@ -108,6 +109,22 @@ urlpatterns = [
          ChangePasswordView.as_view(form_class=ChangePasswordForm),
          name='account_password'),
 
+    path('account/password/reset/done/',
+         TemplateView.as_view(template_name = 'account/password_reset_sent.html'),
+         name='account-password-reset-done'),
+
+    re_path(r'^account/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$',
+            account_views.PasswordResetFromKeyView.as_view(),
+            name="account_reset_password_from_key"),
+
+    path('account/password/reset/fail/',
+         TemplateView.as_view(template_name = 'account/password_reset_token_fail.html'),
+         name='account-password-reset-fail'),
+
+    path('account/password/reset/',
+         PasswordResetView.as_view(),
+         name='account_reset_password'),
+
     path('account/delete/',
          account_views.UserDeleteView.as_view(),
          name='account_delete'),
@@ -116,7 +133,6 @@ urlpatterns = [
     path('account/login/oauth2/', views.OAuth2LoginView.as_view(),
          name='account-login-oauth2'),
 
-    # This has to be after the overriden account/ URLs, not before
     path('account/', include('allauth.urls')),
 
     # Member views of their own accounts.

--- a/open_humans/urls.py
+++ b/open_humans/urls.py
@@ -1,4 +1,5 @@
-from account.views import ChangePasswordView, PasswordResetTokenView
+from allauth.account.views import PasswordChangeView as ChangePasswordView
+from allauth.account.views import PasswordResetView
 
 from django.conf import settings
 from django.urls import include, path, re_path
@@ -107,12 +108,6 @@ urlpatterns = [
          ChangePasswordView.as_view(form_class=ChangePasswordForm),
          name='account_password'),
 
-    re_path(r'^account/password/reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
-            PasswordResetTokenView.as_view(form_class=PasswordResetTokenForm),
-            name='account_password_reset_token'),
-
-    # django-account's built-in delete uses a configurable expunge timer,
-    # let's just do it immediately and save the complexity
     path('account/delete/',
          account_views.UserDeleteView.as_view(),
          name='account_delete'),
@@ -122,7 +117,7 @@ urlpatterns = [
          name='account-login-oauth2'),
 
     # This has to be after the overriden account/ URLs, not before
-    path('account/', include('account.urls')),
+    path('account/', include('allauth.urls')),
 
     # Member views of their own accounts.
     path('member/me/', member_views.MemberDashboardView.as_view(),

--- a/private_sharing/templates/private_sharing/join-on-site-login.html
+++ b/private_sharing/templates/private_sharing/join-on-site-login.html
@@ -46,7 +46,7 @@
 
   <div class="col-xs-12 text-center small">
     <p>
-      <a href="{% url 'account_password_reset' %}">Reset&nbsp;password</a>
+      <a href="{% url 'account_reset_password' %}">Reset&nbsp;password</a>
     </p>
   </div>
 </div>

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,6 @@ django-pylibmc
 django-recaptcha
 djangorestframework-filters
 django-storages
-django-user-accounts
 djangorestframework
 factory-boy
 feedparser

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ boto3
 brotlipy
 dj-database-url
 Django==2.1.1
+django-allauth
 django-appconf
 django-bootstrap-pagination
 django-cors-headers
@@ -36,11 +37,9 @@ Markdown
 mock
 Pillow  # for sorl-thumbnail
 psycopg2-binary
-python-social-auth
 raven
 requests
 selenium
-social-auth-app-django
 sorl-thumbnail
 termcolor
 uWSGI

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,9 @@ chardet==3.0.4            # via requests
 click==6.7
 configparser==3.5.0       # via tini
 coverage==4.5.1
-defusedxml==0.5.0         # via python3-openid, social-auth-core
+defusedxml==0.5.0         # via python3-openid
 dj-database-url==0.5.0
+django-allauth==0.37.1
 django-appconf==1.0.2
 django-bootstrap-pagination==1.6.4
 django-cors-headers==2.4.0
@@ -64,27 +65,23 @@ markdown==2.6.11
 markupsafe==1.0           # via jinja2
 mock==2.0.0
 oauth2==1.9.0.post1       # via flask-oauth
-oauthlib==2.1.0           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
+oauthlib==2.1.0           # via django-oauth-toolkit, requests-oauthlib
 pbr==4.2.0                # via mock
 pillow==5.2.0
 psutil==5.4.6             # via django-gulp
 psycopg2-binary==2.7.5
 pycparser==2.18           # via cffi
-pyjwt==1.6.4              # via social-auth-core
 pylibmc==1.5.2            # via django-pylibmc
 python-dateutil==2.7.3    # via arrow, botocore, faker
 python-magic==0.4.15
-python-social-auth==0.3.6
-python3-openid==3.1.0     # via social-auth-core
+python3-openid==3.1.0     # via django-allauth
 pytz==2018.5              # via django, django-user-accounts
 raven==6.9.0
-requests-oauthlib==1.0.0  # via social-auth-core
+requests-oauthlib==1.0.0  # via django-allauth
 requests==2.19.1
 s3transfer==0.1.13        # via boto3
 selenium==3.13.0
-six==1.11.0               # via bleach, django-extensions, env-tools, faker, html5lib, mock, python-dateutil, social-auth-app-django, social-auth-core, tini
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0   # via python-social-auth, social-auth-app-django
+six==1.11.0               # via bleach, django-extensions, env-tools, faker, html5lib, mock, python-dateutil, tini
 sorl-thumbnail==12.4.1
 sqlparse==0.2.4           # via django-debug-toolbar
 termcolor==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ django-oauth-toolkit==1.2.0
 django-pylibmc==0.6.1
 django-recaptcha==1.4.0
 django-storages==1.6.6
-django-user-accounts==2.0.3
 django==2.1.1
 djangorestframework-filters==0.10.2
 djangorestframework==3.8.2
@@ -75,7 +74,7 @@ pylibmc==1.5.2            # via django-pylibmc
 python-dateutil==2.7.3    # via arrow, botocore, faker
 python-magic==0.4.15
 python3-openid==3.1.0     # via django-allauth
-pytz==2018.5              # via django, django-user-accounts
+pytz==2018.5              # via django
 raven==6.9.0
 requests-oauthlib==1.0.0  # via django-allauth
 requests==2.19.1


### PR DESCRIPTION
## General Checkups
- [*] Have you checked that there aren't other open pull requests for the same issue/update/change?
- [*] If your code includes new features and not just bug fixes/copy editing: Did you include new tests?

## Description
So far, this is an in-place replacement for django-user-accounts.

## Related Issue
#865

## Note
Probably should figure out what to do with the tables we are no longer going to use.  We may also want to associate the existing account_account table which contains timezone and language information with each user, and continue to populate it with new users.
