### PR TITLE
New hack to add template dir for a bulk email

### DIFF
--- a/open_humans/management/commands/bulk_email.py
+++ b/open_humans/management/commands/bulk_email.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         email_file = full_path(options['email_file'])
 
         email_data = []
-        with open(email_file, 'rb') as f:
+        with open(email_file, 'r') as f:
             csvreader = csv.reader(f)
             headers = next(csvreader)
             if 'email' not in headers:
@@ -90,7 +90,6 @@ class Command(BaseCommand):
                     data[headers[i]] = row[i]
                 email_data.append(data)
 
-        path = (os.path.dirname(template),)
         name = os.path.basename(template)
 
         messages = []
@@ -102,10 +101,10 @@ class Command(BaseCommand):
             context = {'user': user}
             for item in data.keys():
                 context[item] = data[item]
-            subject = render_to_string('{}.subject'.format(name), context,
-                                       dirs=path).strip()
-            plain = render_to_string('{}.txt'.format(name), context, dirs=path)
-            html = render_to_string('{}.html'.format(name), context, dirs=path)
+            subject = render_to_string('{}.subject'.format(name),
+                                       context).strip()
+            plain = render_to_string('{}.txt'.format(name), context)
+            html = render_to_string('{}.html'.format(name), context)
 
             messages.append((subject, plain, html, None, (data['email'],)))
 

--- a/open_humans/management/commands/bulk_email.py
+++ b/open_humans/management/commands/bulk_email.py
@@ -78,7 +78,7 @@ class Command(BaseCommand):
             headers = next(csvreader)
             if 'email' not in headers:
                 raise ValueError(
-                    "{} does not have 'email' as one of the header row "
+                    "{0} does not have 'email' as one of the header row "
                     'columns.'.format(options['email_file']))
             if 'user' in headers:
                 raise ValueError(
@@ -101,10 +101,10 @@ class Command(BaseCommand):
             context = {'user': user}
             for item in data.keys():
                 context[item] = data[item]
-            subject = render_to_string('{}.subject'.format(name),
+            subject = render_to_string('{0}.subject'.format(name),
                                        context).strip()
-            plain = render_to_string('{}.txt'.format(name), context)
-            html = render_to_string('{}.html'.format(name), context)
+            plain = render_to_string('{0}.txt'.format(name), context)
+            html = render_to_string('{0}.html'.format(name), context)
 
             messages.append((subject, plain, html, None, (data['email'],)))
 

--- a/open_humans/settings.py
+++ b/open_humans/settings.py
@@ -294,6 +294,9 @@ TEMPLATES = [
     },
 ]
 
+if os.getenv('BULK_EMAIL_TEMPLATE_DIR'):
+    TEMPLATES[0]['DIRS'].append(os.getenv('BULK_EMAIL_TEMPLATE_DIR'))
+
 ROOT_URLCONF = 'open_humans.urls'
 
 WSGI_APPLICATION = 'open_humans.wsgi.application'


### PR DESCRIPTION
## Description
the `bulk_email` management command used to specific a custom template directory on the fly for rendering the emails. this is no longer available. This update works around the issue by allowing someone to specify an environment variable for an additional template directory (which contains the templates used for the email that will be sent)