### PR TITLE
fix messages thing

### DIFF
--- a/open_humans/templates/base.html
+++ b/open_humans/templates/base.html
@@ -126,7 +126,6 @@
     </nav>
 
     <div class="body-main">
-      {% block body_main %}
       <div class="container">
         {% block messages_block %}
           {% if messages %}
@@ -141,6 +140,7 @@
 
         {% block main %}{% endblock %}
       </div>
+      {% block body_main %}
       {% endblock body_main %}
     </div>
 


### PR DESCRIPTION
## Description
Somehow the main block in the base template got moved around and was overwriting the message code.

## Related Issue
913

## Testing

  * passed automated testing locally
  * ran locally to test manually:
    * messages still show up on pages based on the panel template
    * messages show up on pages based on the base.html template
    * messages do not show up twice on panel pages

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>