### PR TITLE
add withdrawn link

### DIFF
--- a/private_sharing/templates/private_sharing/project-detail.html
+++ b/private_sharing/templates/private_sharing/project-detail.html
@@ -126,6 +126,13 @@
 {% endif %}
 </dl>
 
+<h4>Withdrawn members</h4>
+<p>
+  <a href="{% url 'direct-sharing:withdrawn-members' slug=object.slug %}">This
+  page contains a listing</a> of members that have withdrawn from this project
+  and whether or not they have requested that their data be deleted.
+</p>
+
 <h4>API access credentials</h4>
 
 <p><em>Please keep your master access token safe! Tokens last for 24 hours.

--- a/private_sharing/templates/private_sharing/project-detail.html
+++ b/private_sharing/templates/private_sharing/project-detail.html
@@ -16,10 +16,13 @@
 <p>
   <a class="btn btn-default"
     href="{% url 'direct-sharing:message-members' slug=object.slug %}">
-    Message project members</a>
+    Message members</a>
+  <a class="btn btn-default"
+    href="{% url 'direct-sharing:withdrawn-members' slug=object.slug %}">
+    List withdrawals</a>
   <a class="btn btn-danger"
     href="{% url 'direct-sharing:remove-members' slug=object.slug %}">
-    Remove project members</a>
+    Remove members</a>
 </p>
 
 <hr>
@@ -125,13 +128,6 @@
   </dd>
 {% endif %}
 </dl>
-
-<h4>Withdrawn members</h4>
-<p>
-  <a href="{% url 'direct-sharing:withdrawn-members' slug=object.slug %}">This
-  page contains a listing</a> of members that have withdrawn from this project
-  and whether or not they have requested that their data be deleted.
-</p>
 
 <h4>API access credentials</h4>
 

--- a/private_sharing/templates/private_sharing/project-withdrawn-members-view.html
+++ b/private_sharing/templates/private_sharing/project-withdrawn-members-view.html
@@ -8,8 +8,9 @@
 
 <h3>Members project members</h3>
 
-Below you can find a listing of the project members that have requested erasure
-of their data from &#34;{{ object.name }}&#34;.
+Below you can find a listing of the project members that have left the
+project, and whether they have requested erasure of their data from
+&#34;{{ object.name }}&#34;.
 
 <hr>
 


### PR DESCRIPTION
## Description
Include a link on the activity page to the withdrawn members page

## Related Issue
911

## Testing
  * passed automated testing locally
  * activity page loads
  * link to withdrawn list page works

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>