### PR TITLE
Do not allow authorizations with inactive oauth2 projects

### DIFF
--- a/private_sharing/templates/private_sharing/authorize-inactive.html
+++ b/private_sharing/templates/private_sharing/authorize-inactive.html
@@ -1,7 +1,5 @@
 {% extends 'panel.html' %}
 
-{% load utilities %}
-
 {% block head_title %}
 Authorization not possible
 {% endblock %}

--- a/private_sharing/templates/private_sharing/authorize-inactive.html
+++ b/private_sharing/templates/private_sharing/authorize-inactive.html
@@ -1,0 +1,14 @@
+{% extends 'panel.html' %}
+
+{% load utilities %}
+
+{% block head_title %}
+Authorization not possible
+{% endblock %}
+
+{% block panel_content %}
+
+Unfortunately, this project is not currently active.
+<p></p>
+
+{% endblock %}

--- a/private_sharing/urls.py
+++ b/private_sharing/urls.py
@@ -27,6 +27,11 @@ urlpatterns = [
          views.AuthorizeOAuth2ProjectView.as_view(),
          name='authorize-oauth2'),
 
+    path('authorize-inactive/',
+         TemplateView.as_view(
+             template_name='private_sharing/authorize-inactive.html'),
+         name='authorize-inactive'),
+
     re_path(r'^projects/leave/(?P<pk>[0-9]+)/$',
             views.ProjectLeaveView.as_view(),
             name='leave-project'),


### PR DESCRIPTION
## Description
While oauth2 projects would no longer show up anywhere on Open Humans, the external components of the project could still send people to be authorized.

## Related Issue
796

## Testing
  * passed automated testing locally
  * tested authorizing with active oauth2 project
  * test authorizing with inactive oauth2 project
  * tested authorizing with empty client_id


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>