### PR TITLE
Hide events involving projects in Activity Feed if the member has selected to hide membership

### DIFF
--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -240,9 +240,10 @@ class HomeView(NeverCacheMixin, SourcesContextMixin, TemplateView):
         """
         Lists the 12 most recent actions by users.
         """
-        # Here we must use raw sql because the ORM is not quite able to do
-        # the complex 'where' we have here, or at least that's the consensus
-        # in #django on freenode
+        # Here we must use raw sql because the ORM is not quite able to take
+        # a queryset, look up two separate foreign keys in two separate models
+        # to get an object from a fourth model and return that to filter the
+        # first queryset.
         sql = ("select id from private_sharing_activityfeed where " +
                "(member_id, project_id) IN (select member_id, project_id " +
                "from private_sharing_datarequestprojectmember " +

--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -237,8 +237,7 @@ class HomeView(NeverCacheMixin, SourcesContextMixin, TemplateView):
 
     @staticmethod
     def get_recent_activity():
-        recent_qs = ActivityFeed.objects.annotate(drpm=DataRequestProjectMember.objects.filter(member=F('member'), project=F('project'))).filter(drpm__visible=True)
-        recent = recent_qs.order_by('-timestamp')[0:12]
+        recent = ActivityFeed.objects.order_by('-timestamp')[0:12]
         recent_1 = recent[:int((len(recent)+1)/2)]
         recent_2 = recent[int((len(recent)+1)/2):]
         return (recent_1, recent_2)


### PR DESCRIPTION
## Description
With this PR, all events relating to projects no longer show up in the Activity Feed if the user has set membership in that public to hidden.

## Related Issue
#898 

## Testing

  * passed automated testing locally
  * ran locally to test manually:
    * Confirmed that joining project still shows up as a New Member entry
    * If you join a project and choose to hide membership, joining does not show up in Activity Feed.
    * If join project but leave membership visible, the joining shows up
    * If you join, leave membership visible, and subsequently set membership to hidden, you no longer show up