### PR TITLE
Don't require ssl for local

### DIFF
--- a/open_humans/settings.py
+++ b/open_humans/settings.py
@@ -316,7 +316,10 @@ if os.getenv('CI_NAME') == 'codeship':
         'PORT': 5434
     }
 elif dj_database_url.config():
-    DATABASES['default'] = dj_database_url.config(ssl_require=True)
+    if not SSLIFY_DISABLE:
+        DATABASES['default'] = dj_database_url.config(ssl_require=True)
+    else:
+        DATABASES['default'] = dj_database_url.config(ssl_require=False)
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/


### PR DESCRIPTION
## Description
Due to a 'get the fix out the door' thing when heroku started requiring ssl for db connections, did not properly account for running locally (e.g. without ssl).  This commit fixes that oversight.

## Related Issue
Not officially reported

## Testing
ran the server with manage.py runserver
ran automated tests

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>