### PR TITLE
downgrade to pylibmc-1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ pillow==5.4.1
 psutil==5.4.8             # via django-gulp
 psycopg2==2.7.6.1         # via django-heroku
 pycparser==2.19           # via cffi
-pylibmc==1.6.0            # via django-pylibmc
+pylibmc==1.5.2            # via django-pylibmc
 python-dateutil==2.7.5    # via arrow, botocore, faker
 python-magic==0.4.15
 python3-openid==3.1.0     # via django-allauth


### PR DESCRIPTION
## Description
upgrading to pylibmc-1.6.0 causes compatibility issues with memcached hosted by heroku; downgrading resolves this.

## Related Issue
N/A

## Testing
Attempted pushing to staging, push fails
Downgrade, push succeeds
Upgraded just to confirm, push fails