### PR TITLE
Add email notification to suspend_users command

### DIFF
--- a/open_humans/management/commands/suspend_users.py
+++ b/open_humans/management/commands/suspend_users.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.mail import get_connection, EmailMultiAlternatives
 from django.core.management.base import BaseCommand, CommandError
 
 UserModel = get_user_model()
@@ -20,6 +21,14 @@ class Command(BaseCommand):
                             dest='id',
                             required=False,
                             help=('one or more ids, comma separated'))
+        parser.add_argument('-e', '--email',
+                            dest='email',
+                            action='store_true',
+                            help='send notification email')
+        parser.add_argument('--skip-suspend',
+                            dest='skip_suspend',
+                            action='store_true',
+                            help='mock run, skip performing actual suspension')
 
     def handle(self, *args, **options):
         users_to_suspend = []
@@ -44,7 +53,40 @@ class Command(BaseCommand):
                     raise CommandError('User ID "{}" does not exist!'
                                        .format(id_str))
 
+        if options['email']:
+            self.email_notification(users_to_suspend)
+
         for user in users_to_suspend:
-            user.is_active = False
-            user.save()
+            if not options['skip_suspend']:
+                user.is_active = False
+                user.save()
             print('{} (ID: {}) is suspended.'.format(user.username, user.id))
+
+    def _body_text(self, username):
+        body_text = """{0},
+
+Your Open Humans account (username: "{0}") has been suspended for
+misuse of the platform. We want to ensure that the site is not misused,
+e.g. for advertising spam.
+
+If this was done in error, please reply to this email to let us know!
+There are sometimes mistakes in detecting spam accounts and other abuses.
+
+Sincerely,
+
+Open Humans
+""".format(username)
+        return body_text
+
+    def email_notification(self, users):
+        subject = 'Open Humans: Account suspension notification'
+
+        messages = []
+        for user in users:
+            body_text = self._body_text(user.username)
+            message = EmailMultiAlternatives(
+                subject, body_text, None, [user.email])
+            messages.append(message)
+
+        connection = get_connection()
+        connection.send_messages(messages)

--- a/open_humans/management/commands/suspend_users.py
+++ b/open_humans/management/commands/suspend_users.py
@@ -25,10 +25,6 @@ class Command(BaseCommand):
                             dest='email',
                             action='store_true',
                             help='send notification email')
-        parser.add_argument('--skip-suspend',
-                            dest='skip_suspend',
-                            action='store_true',
-                            help='mock run, skip performing actual suspension')
 
     def handle(self, *args, **options):
         users_to_suspend = []
@@ -57,9 +53,8 @@ class Command(BaseCommand):
             self.email_notification(users_to_suspend)
 
         for user in users_to_suspend:
-            if not options['skip_suspend']:
-                user.is_active = False
-                user.save()
+            user.is_active = False
+            user.save()
             print('{} (ID: {}) is suspended.'.format(user.username, user.id))
 
     def _body_text(self, username):


### PR DESCRIPTION
Adds an email notification to the account suspension management command.

Tested locally with console email and local database.