### PR TITLE
Fix css 404

### DIFF
--- a/open_humans/templates/member/member-list.html
+++ b/open_humans/templates/member/member-list.html
@@ -13,8 +13,6 @@
     href="{% static 'vendor/select2.min.css' %}">
   <link rel="stylesheet" type="text/css"
     href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.9/select2-bootstrap.css">
-  <link rel="stylesheet" type="text/css"
-    href="{% static 'css/_pages-members.css' %}">
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
## Description
I included the page css for /members/ directly in the html template, however, the site is setup to include it in main.css, and this was causing conflicts within gulp that only showed up in production.

## Related Issue
Sentry reports

## Testing
Reran collectstatic and ensured that the contents of /static/css/_pages-members.css was included in /css/main.css

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>