### PR TITLE
Reduce number of database hits for exchange-member endpoint

### DIFF
--- a/data_import/models.py
+++ b/data_import/models.py
@@ -125,7 +125,10 @@ class DataFile(models.Model):
         return self.file.storage.url(self.file.name)
 
     def private_download_url(self, request):
-        if self.is_public:
+        if hasattr(request, 'public_sources'):
+            if request.public_sources.filter(data_source=self.source):
+                return self.download_url
+        elif self.is_public:
             return self.download_url
         key = self.generate_key(request)
         return '{0}?key={1}'.format(self.download_url, key)
@@ -150,7 +153,7 @@ class DataFile(models.Model):
         return new_key.key
 
     @property
-    def is_public(self):
+    def is_public(self, public_sources=None):
         return is_public(self.user.member, self.source)
 
     def has_access(self, user=None):

--- a/data_import/models.py
+++ b/data_import/models.py
@@ -126,7 +126,7 @@ class DataFile(models.Model):
 
     def private_download_url(self, request):
         if hasattr(request, 'public_sources'):
-            if request.public_sources.filter(data_source=self.source):
+            if self.source in request.public_sources:
                 return self.download_url
         elif self.is_public:
             return self.download_url

--- a/data_import/models.py
+++ b/data_import/models.py
@@ -153,7 +153,7 @@ class DataFile(models.Model):
         return new_key.key
 
     @property
-    def is_public(self, public_sources=None):
+    def is_public(self):
         return is_public(self.user.member, self.source)
 
     def has_access(self, user=None):

--- a/private_sharing/serializers.py
+++ b/private_sharing/serializers.py
@@ -85,11 +85,14 @@ class ProjectMemberDataSerializer(serializers.ModelSerializer):
             files = all_files.filter(
                 source__in=obj.sources_shared_including_self)
         request = self.context.get('request', None)
+        request.public_sources = (obj.member.public_data_participant
+                          .publicdataaccess_set
+                          .filter(is_public=True))
         return [DataFileSerializer(data_file, context={'request': request}).data
                 for data_file in files]
 
     def to_representation(self, obj):
-        rep = super(ProjectMemberDataSerializer, self).to_representation(obj)
+        rep = super().to_representation(obj)
 
         if not rep['username']:
             rep.pop('username')

--- a/private_sharing/serializers.py
+++ b/private_sharing/serializers.py
@@ -85,9 +85,11 @@ class ProjectMemberDataSerializer(serializers.ModelSerializer):
             files = all_files.filter(
                 source__in=obj.sources_shared_including_self)
         request = self.context.get('request', None)
-        request.public_sources = (obj.member.public_data_participant
-                          .publicdataaccess_set
-                          .filter(is_public=True))
+        request.public_sources = list(obj.member.public_data_participant
+                                      .publicdataaccess_set
+                                      .filter(is_public=True)
+                                      .values_list('data_source',
+                                                   flat=True))
         return [DataFileSerializer(data_file, context={'request': request}).data
                 for data_file in files]
 


### PR DESCRIPTION
## Description
This change reduces the number of database hits on the exchange member endpoint, from over a thousand for a large set of files, to under 20.

## Related Issue
Server slowness

## Testing
Was able to reproduce on a local copy of the production database using an access_key for a user that was known to have a large file set.
Silk profiling indicates greatly reduced number of queries, plus greatly reduced execution time

Tested other endpoints that hit the same code in the datafile model to ensure that they continued to function as expected.