### PR TITLE
add black pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Website](http://openhumans.org/).
 
 #### dependencies
 
-- python >=3.5
+- python >=3.6
 - pip3
 - virtualenv (`pip3 install virtualenv`)
 - nodejs 6.x
@@ -31,8 +31,8 @@ For the following commands, you'll also want to set up virtualenvwrapper:
 - `pip3 install virtualenvwrapper`
 - Follow setup instructions here (e.g. modify your `.bashrc` as needed): http://virtualenvwrapper.readthedocs.io/en/latest/install.html
 
-Create a virtualenv:
-- `mkvirtualenv open-humans`
+Create a virtualenv for Python 3.6, e.g.:
+- `mkvirtualenv open-humans --python=/usr/bin/python3.6`
 - `pip3 install -r requirements.txt -r dev-requirements.txt`
 
 In the future, start the virtual environment with:
@@ -93,9 +93,9 @@ You need to process static files before you can run tests.
 1. `./manage.py collectstatic`
 2. `./manage.py test`
 
-#### Linting
+#### Linting & formatting
 
-- flake8
-- pep256
-- pylint
-- eslint (`npm install -g eslint`)
+Please use `black` to format code prior to commits. Set up a
+pre-commit hook by running the following:
+
+1. `pre-commit install`

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,6 +1,8 @@
+black
 flake8
 flake8-quotes
 ipython
 pip-tools
+pre-commit
 pydocstyle
 pylint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,22 +4,32 @@
 #
 #    pip-compile --output-file dev-requirements.txt dev-requirements.in
 #
+appdirs==1.4.3            # via black
+aspy.yaml==1.1.2          # via pre-commit
 astroid==2.1.0            # via pylint
+attrs==18.2.0             # via black
 backcall==0.1.0           # via ipython
-click==7.0                # via pip-tools
+black==18.9b0
+cfgv==1.4.0               # via pre-commit
+click==7.0                # via black, pip-tools
 decorator==4.3.0          # via ipython, traitlets
 flake8-quotes==1.0.0
 flake8==3.6.0
+identify==1.2.1           # via pre-commit
+importlib-metadata==0.8   # via pre-commit
+importlib-resources==1.0.2  # via pre-commit
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.2.0
 isort==4.3.4              # via pylint
 jedi==0.13.2              # via ipython
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via flake8, pylint
+nodeenv==1.3.3            # via pre-commit
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pip-tools==3.2.0
+pre-commit==1.14.3
 prompt-toolkit==2.0.7     # via ipython
 ptyprocess==0.6.0         # via pexpect
 pycodestyle==2.4.0        # via flake8
@@ -27,8 +37,13 @@ pydocstyle==3.0.0
 pyflakes==2.0.0           # via flake8
 pygments==2.3.1           # via ipython
 pylint==2.2.2
-six==1.12.0               # via astroid, pip-tools, prompt-toolkit, pydocstyle, traitlets
+pyyaml==3.13              # via aspy.yaml, pre-commit
+six==1.12.0               # via astroid, cfgv, pip-tools, pre-commit, prompt-toolkit, pydocstyle, traitlets
 snowballstemmer==1.2.1    # via pydocstyle
+toml==0.10.0              # via black, pre-commit
 traitlets==4.3.2          # via ipython
+typed-ast==1.3.1          # via astroid
+virtualenv==16.4.0        # via pre-commit
 wcwidth==0.1.7            # via prompt-toolkit
 wrapt==1.11.0             # via astroid
+zipp==0.3.3               # via importlib-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.black]
+line-length = 88
+py36 = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | migrations
+  | static-files
+
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+)/
+'''


### PR DESCRIPTION
This adds `black` to development requirements and the setup for a pre-commit hook.

After this I think we'll want to make sure to run black on files first, as a separate commit in the main repository's git history, separate to new code changes.