### PR TITLE
Bump python version due to vulnerabilities

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.6.8


### PR DESCRIPTION
Python 3.6.6 has a rather nasty vulnerability with certs.

Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>
