### PR TITLE
Paginate member exchange endpoint

### DIFF
--- a/data_import/serializers.py
+++ b/data_import/serializers.py
@@ -19,14 +19,13 @@ class DataFileSerializer(serializers.Serializer):
         datafile model's private_download_url function for logging purposes when
         keys are created.
         """
+        request = self.context.get("request", None)
         ret = OrderedDict()
-        fields = ["id", "basename", "created", "download_url", "metadata", "source"]
-        for field in fields:
-            if field == "download_url":
-                ret[field] = instance.private_download_url(
-                    self.context.get("request", None)
-                )
-            else:
-                ret[field] = getattr(instance, field)
+        ret["id"] = instance.id
+        ret["basename"] = instance.basename
+        ret["created"] = instance.created
+        ret["download_url"] = instance.private_download_url(request)
+        ret["metadata"] = instance.metadata
+        ret["source"] = instance.source
 
         return ret

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -14,6 +14,8 @@ from rest_framework.views import APIView
 
 from common.mixins import NeverCacheMixin
 
+from data_import.models import DataFile
+from data_import.serializers import DataFileSerializer
 from data_import.utils import get_upload_path
 
 from .api_authentication import CustomOAuth2Authentication, MasterTokenAuthentication
@@ -86,14 +88,14 @@ class ProjectDataView(ProjectDetailView):
     serializer_class = ProjectDataSerializer
 
 
-class ProjectMemberExchangeView(NeverCacheMixin, RetrieveAPIView):
+class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
     """
     Return the project member information attached to the OAuth2 access token.
     """
 
     authentication_classes = (CustomOAuth2Authentication,)
     permission_classes = (HasValidProjectToken,)
-    serializer_class = ProjectMemberDataSerializer
+    serializer_class = DataFileSerializer
     max_limit = 150
     default_limit = 100
 
@@ -108,6 +110,56 @@ class ProjectMemberExchangeView(NeverCacheMixin, RetrieveAPIView):
         return DataRequestProjectMember.objects.get(
             member=self.request.user.member, project=project
         )
+
+    def get_sources_shared(self, obj):
+        """
+        Get the other sources this project requests access to.
+        """
+        return [source.id_label for source in obj.granted_sources.all()]
+
+    def get_username(self):
+        """
+        Only return the username if the user has shared it with the project.
+        """
+        if self.obj.username_shared:
+            return self.obj.member.user.username
+
+        return None
+
+    def get_queryset(self):
+        """
+        Get the queryset of DataFiles that belong to a member in a project
+        """
+        self.obj = self.get_object()
+
+        all_files = DataFile.objects.filter(user=self.obj.member.user).exclude(
+            parent_project_data_file__completed=False
+        )
+
+        if self.obj.all_sources_shared:
+            files = all_files
+        else:
+            sources_shared = self.get_sources_shared(self.obj)
+            sources_shared.append(self.obj.project.id_label)
+            files = all_files.filter(source__in=sources_shared)
+        return files
+
+    def list(self, request, *args, **kwargs):
+        """
+        Add the additional fields to the api endpoint that our API is expected to have.
+        """
+        ret = super().list(request, *args, **kwargs)
+        ret.data.update({"created": self.obj.created})
+        ret.data.update({"project_member_id": self.obj.project_member_id})
+        ret.data.update({"sources_shared": self.get_sources_shared(self.obj)})
+        username = self.get_username()
+        if username:
+            ret.data.update({"username": username})
+        # The list api returns 'results' but our api is expected to return 'data'
+        # This renames the key
+        data = ret.data.pop("results")
+        ret.data.update({"data": data})
+        return ret
 
 
 class ProjectMemberDataView(ProjectListView):

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -94,6 +94,8 @@ class ProjectMemberExchangeView(NeverCacheMixin, RetrieveAPIView):
     authentication_classes = (CustomOAuth2Authentication,)
     permission_classes = (HasValidProjectToken,)
     serializer_class = ProjectMemberDataSerializer
+    max_limit = 150
+    default_limit = 100
 
     def get_object(self):
         """

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -131,7 +131,11 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
         Get the queryset of DataFiles that belong to a member in a project
         """
         self.obj = self.get_object()
-
+        self.request.public_sources = list(
+            self.obj.member.public_data_participant.publicdataaccess_set.filter(
+                is_public=True
+            ).values_list("data_source", flat=True)
+        )
         all_files = DataFile.objects.filter(user=self.obj.member.user).exclude(
             parent_project_data_file__completed=False
         )
@@ -158,6 +162,7 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
         # The list api returns 'results' but our api is expected to return 'data'
         # This renames the key
         data = ret.data.pop("results")
+        print(data)
         ret.data.update({"data": data})
         return ret
 

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -96,7 +96,7 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
     authentication_classes = (CustomOAuth2Authentication,)
     permission_classes = (HasValidProjectToken,)
     serializer_class = DataFileSerializer
-    max_limit = 150
+    max_limit = 200
     default_limit = 100
 
     def get_object(self):

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -162,7 +162,6 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
         # The list api returns 'results' but our api is expected to return 'data'
         # This renames the key
         data = ret.data.pop("results")
-        print(data)
         ret.data.update({"data": data})
         return ret
 

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -20,12 +20,12 @@
 </code></p>
 <p>
   This returns JSON-formatted data that can be used to
-  programmatically access and retrieve data and files for this
-  specific project member.  This data is paginated.  The returned JSON
-  includes "count", which is the total number of files, a "next" key
-  that, if there is more than one page of data will have the URL for
-  the next page, and a "previous" key that will point to a URL that
-  will point to the previous page of data.
+  programmatically access and retrieve data files for this
+  specific project member. Data file information is paginated and,
+  by default, lists a maximum of 100 data files. The returned JSON
+  includes: "count", which is the total number of files, "next",
+  the URL for the next page of data files (if there are more to be listed),
+  and "previous", the URL for the previous page of data (if one exists).
 </p>
 
 <h4>Social log in with an Open Humans account</h4>

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -23,9 +23,9 @@
   programmatically access and retrieve data files and other information for this
   specific project member. Data file information is paginated and,
   by default, lists a maximum of 100 data files. The returned JSON
-  includes: "count", which is the total number of files, "next",
+  includes: "count", which is the total number of data files, "next",
   the URL for the next page of data files (if there are more to be listed),
-  and "previous", the URL for the previous page of data (if one exists).
+  and "previous", the URL for the previous page of data files (if one exists).
 </p>
 
 <h4>Social log in with an Open Humans account</h4>

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -20,7 +20,7 @@
 </code></p>
 <p>
   This returns JSON-formatted data that can be used to
-  programmatically access and retrieve data files for this
+  programmatically access and retrieve data files and other information for this
   specific project member. Data file information is paginated and,
   by default, lists a maximum of 100 data files. The returned JSON
   includes: "count", which is the total number of files, "next",

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -19,8 +19,13 @@
   https://www.openhumans.org/api/direct-sharing/project/exchange-member/?access_token=&lt;USER_ACCESS_TOKEN&gt;
 </code></p>
 <p>
-  This returns JSON-formatted data that can be used to programmatically
-  access and retrieve data and files for this specific project member.
+  This returns JSON-formatted data that can be used to
+  programmatically access and retrieve data and files for this
+  specific project member.  This data is paginated.  The returned JSON
+  includes "count", which is the total number of files, a "next" key
+  that, if there is more than one page of data will have the URL for
+  the next page, and a "previous" key that will point to a URL that
+  will point to the previous page of data.
 </p>
 
 <h4>Social log in with an Open Humans account</h4>


### PR DESCRIPTION
## Description
The member exchange endpoint is very slow when a member has a large number of files for a project.  This change paginates the member exchange, which limits the number of returned results.  In addition, a hard limit of 150 was set.

## Related Issue
N/A

## Testing
Verified that, besides additional fields added by listapiview and results are now truncated at the set limit, the results returned are the same as originally
Instrumented with Silk to ensure that there were no speed problems introduced
Verified that all files were correctly listed.