### PR TITLE
Limit returned files project members api endpoint and point to exchange-member endpoint for full file list

### DIFF
--- a/private_sharing/api_urls.py
+++ b/private_sharing/api_urls.py
@@ -7,7 +7,11 @@ from . import api_views
 urlpatterns = [
     path("project/", api_views.ProjectDataView.as_view()),
     path("project/members/", api_views.ProjectMemberDataView.as_view()),
-    path("project/exchange-member/", api_views.ProjectMemberExchangeView.as_view()),
+    path(
+        "project/exchange-member/",
+        api_views.ProjectMemberExchangeView.as_view(),
+        name="exchange-member",
+    ),
     path("project/message/", api_views.ProjectMessageView.as_view()),
     path("project/remove-members/", api_views.ProjectRemoveMemberView.as_view()),
     # Views for managing uploaded data files

--- a/private_sharing/serializers.py
+++ b/private_sharing/serializers.py
@@ -1,5 +1,8 @@
+from django.urls import reverse
+
 from rest_framework import serializers
 
+from common.utils import full_url
 from data_import.models import DataFile
 from data_import.serializers import DataFileSerializer
 
@@ -63,8 +66,18 @@ class ProjectMemberDataSerializer(serializers.ModelSerializer):
     class Meta:  # noqa: D101
         model = DataRequestProjectMember
 
-        fields = ["created", "project_member_id", "sources_shared", "username", "data"]
+        fields = [
+            "created",
+            "project_member_id",
+            "file_count",
+            "exchange_member",
+            "sources_shared",
+            "username",
+            "data",
+        ]
 
+    file_count = serializers.SerializerMethodField()
+    exchange_member = serializers.SerializerMethodField()
     username = serializers.SerializerMethodField()
     data = serializers.SerializerMethodField()
 
@@ -73,6 +86,39 @@ class ProjectMemberDataSerializer(serializers.ModelSerializer):
         Get the other sources this project requests access to.
         """
         return [source.id_label for source in obj.granted_sources.all()]
+
+    def get_qs(self, obj):
+        """
+        Returns a queryset of user's files.
+        """
+        all_files = DataFile.objects.filter(user=obj.member.user).exclude(
+            parent_project_data_file__completed=False
+        )
+        if obj.all_sources_shared:
+            files = all_files
+        else:
+            sources_shared = self.get_sources_shared(obj)
+            sources_shared.append(obj.project.id_label)
+            files = all_files.filter(source__in=sources_shared)
+        return files
+
+    def get_file_count(self, obj):
+        """
+        Gets count of files
+        """
+        files = self.get_qs(obj)
+        return files.count()
+
+    def get_exchange_member(self, obj):
+        """
+        Returns a link to the member exchange endpoint to further retrieve a user's files.
+        """
+        # Pass through the access token
+        access_token = self.context["request"].GET["access_token"]
+        exchange_member = reverse("exchange-member")
+        return "{0}?project_member_id={1}&access_token={2}".format(
+            full_url(exchange_member), obj.project_member_id, access_token
+        )
 
     @staticmethod
     def get_username(obj):
@@ -89,15 +135,9 @@ class ProjectMemberDataSerializer(serializers.ModelSerializer):
         Return current data files for each source the user has shared with
         the project, including the project itself.
         """
-        all_files = DataFile.objects.filter(user=obj.member.user).exclude(
-            parent_project_data_file__completed=False
-        )
-        if obj.all_sources_shared:
-            files = all_files
-        else:
-            sources_shared = self.get_sources_shared(obj)
-            sources_shared.append(obj.project.id_label)
-            files = all_files.filter(source__in=sources_shared)
+        # Limit to the first ten files
+        files = self.get_qs(obj)[:10]
+
         request = self.context.get("request", None)
         request.public_sources = list(
             obj.member.public_data_participant.publicdataaccess_set.filter(

--- a/private_sharing/templates/direct-sharing/oauth2-data-access.html
+++ b/private_sharing/templates/direct-sharing/oauth2-data-access.html
@@ -13,7 +13,7 @@
 </p>
 <ul>
   <li>
-    <a href="#api-access-oauth2-member-endpoint">OAuth2 project member endpoint</a>
+    <a href="#api-exchange-member">Project member endpoint</a>
   </li>
   <li>
     <a href="#api-access-master-token">Master access token endpoint</a>

--- a/private_sharing/templates/direct-sharing/on-site-data-access.html
+++ b/private_sharing/templates/direct-sharing/on-site-data-access.html
@@ -13,6 +13,9 @@
 </p>
 <ul>
   <li>
+    <a href="#api-exchange-member">Project member endpoint</a>
+  </li>
+  <li>
     <a href="#master-access-tokens">Master access tokens</a>
   </li>
   <li>

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -22,7 +22,7 @@
 <p>
   The second is to{% else %}The way to use this endpoint is to{% endif %} send a
   secure GET request ('https') to the following URL with the
-  <code>access_token</code> paramater set to the project's "master access token"
+  <code>access_token</code> parameter set to the project's "master access token"
   and the <code>project_member_id</code> set to the project member's "project
   member id".
 <p>
@@ -74,10 +74,10 @@
   with the <code>access_token</code> parameter set to your project's
   "master access token".  This returns JSON-formatted data  with a list of
   the project's members as well as the first ten files that member has shared
-  with the project.  In addition, it provides:  "count", which tallies the
+  with the project.  In addition, it provides:  <code>file_count</code>, which tallies the
   total number of files the member has shared with the project, as well as
-  "exchange_member", which has a link to that member's exchange api endpoint,
-  providing the full list of files.  For more information on this endpoint,
+  <code>exchange_member</code>, which has a link to that member's exchange api endpoint,
+  providing access to the full set of files.  For more information on this endpoint,
   please see the <a href="#api-exchange-member">exchange-member
     endpoint documentation.</a>
 

--- a/private_sharing/templates/direct-sharing/partials/data-access.html
+++ b/private_sharing/templates/direct-sharing/partials/data-access.html
@@ -1,5 +1,4 @@
-{% if oauth2_project %}
-<h3 id="api-access-oauth2-member-endpoint">API data access: OAuth2 project member endpoint</h3>
+<h3 id="api-exchange-member">API data access: Project member endpoint</h3>
 
 <p>
   Using access tokens for specific users, OAuth2 projects can use this
@@ -12,12 +11,20 @@
 </ul>
 
 <p>
-  To use this endpoint, send a secure GET request (using 'https') to the following
-  URL with the 'access_token' parameter set to the user's OAuth2 "access token":
+{% if oauth2_project %}
+  There are two ways to use this endpoint.  The first is to send a secure GET
+  request (using 'https') to the following URL with the <code>access_token</code>
+  parameter set to the user's OAuth2 "access token":
 </p>
 <p><code>
   https://www.openhumans.org/api/direct-sharing/project/exchange-member/?access_token=&lt;USER_ACCESS_TOKEN&gt;
 </code></p>
+<p>
+  The second is to{% else %}The way to use this endpoint is to{% endif %} send a
+  secure GET request ('https') to the following URL with the
+  <code>access_token</code> paramater set to the project's "master access token"
+  and the <code>project_member_id</code> set to the project member's "project
+  member id".
 <p>
   This returns JSON-formatted data that can be used to
   programmatically access and retrieve data files and other information for this
@@ -28,6 +35,7 @@
   and "previous", the URL for the previous page of data files (if one exists).
 </p>
 
+{% if oauth2_project %}
 <h4>Social log in with an Open Humans account</h4>
 
 <p>
@@ -60,10 +68,19 @@
 <h3 id="api-access-master-token">API data access: master access token endpoint</h3>
 
 <p>
+
   To access private data shared with your project, send a secure GET request
   (using 'https') to <code>/api/direct-sharing/project/members/</code>
   with the <code>access_token</code> parameter set to your project's
-  "master access token".
+  "master access token".  This returns JSON-formatted data  with a list of
+  the project's members as well as the first ten files that member has shared
+  with the project.  In addition, it provides:  "count", which tallies the
+  total number of files the member has shared with the project, as well as
+  "exchange_member", which has a link to that member's exchange api endpoint,
+  providing the full list of files.  For more information on this endpoint,
+  please see the <a href="#api-exchange-member">exchange-member
+    endpoint documentation.</a>
+
 </p>
 
 <p>


### PR DESCRIPTION
## Description
Changes the project members api endpoint to a non-configurable ten file per user display limit, adds a total file count, and provides a link with auth credentials and project member id to the exchange member endpoint, which provides a full listing of a member's available files.  In addition, sets the exchange member endpoint to accept a project's master access token to authenticate as well as an individual project member's project member id to specify the project member, while retaining the previous oauth2 access_token behavior.

Updates documentation to reflect these changes.

## Related Issue
N/A

## Testing
Verified that documentation changes display correctly
Verified that the full oauth2 workflow still functions correctly using an oauth2 app
Verified that accessing the exchange member api endpoint with just an oauth2 token works correctly
Verified that the exchange member api endpoint functions correctly with a valid master access token and project member id
Verified that it properly errors if an invalid master access token or project member id is provided
verified that the Project Members endpoint now only displays ten files per user as well as a "count" field and a link to the exchange member endpoint with correct, functioning credentials.


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>
