### PR TITLE
Enable file download key generation globally

### DIFF
--- a/data_import/models.py
+++ b/data_import/models.py
@@ -115,9 +115,10 @@ class DataFile(models.Model):
     def __str__(self):
         return str("{0}:{1}:{2}").format(self.user, self.source, self.file)
 
-    @property
-    def download_url(self):
-        return full_url(reverse("data-management:datafile-download", args=(self.id,)))
+    def download_url(self, request):
+        key = self.generate_key(request)
+        url = full_url(reverse("data-management:datafile-download", args=(self.id,)))
+        return "{0}?key={1}".format(url, key)
 
     @property
     def file_url_as_attachment(self):
@@ -125,15 +126,6 @@ class DataFile(models.Model):
         Get an S3 pre-signed URL specifying content disposation as attachment.
         """
         return self.file.storage.url(self.file.name)
-
-    def private_download_url(self, request):
-        if hasattr(request, "public_sources"):
-            if self.source in request.public_sources:
-                return self.download_url
-        elif self.is_public:
-            return self.download_url
-        key = self.generate_key(request)
-        return "{0}?key={1}".format(self.download_url, key)
 
     def generate_key(self, request):
         """
@@ -143,13 +135,20 @@ class DataFile(models.Model):
         if request:
             # Log the entity that is requesting the key be generated
             new_key.ip_address = get_ip(request)
-            new_key.access_token = request.query_params.get("access_token", None)
-            if hasattr(request.auth, "application"):
-                # oauth2 project auth
-                new_key.project_id = request.auth.application.id
+            if hasattr(request, "query_params"):
+                new_key.access_token = request.query_params.get("access_token", None)
             else:
-                # onsite project auth
-                new_key.project_id = request.auth.id
+                new_key.access_token = None
+            if hasattr(request, "auth"):
+                if hasattr(request.auth, "application"):
+                    # oauth2 project auth
+                    new_key.project_id = request.auth.application.id
+                else:
+                    # onsite project auth
+                    new_key.project_id = request.auth.id
+            else:
+                # We do not have an accessing project
+                new_key.project_id = None
         new_key.save()
         return new_key.key
 

--- a/data_import/models.py
+++ b/data_import/models.py
@@ -135,17 +135,12 @@ class DataFile(models.Model):
         if request:
             # Log the entity that is requesting the key be generated
             new_key.ip_address = get_ip(request)
-            if hasattr(request, "query_params"):
+            try:
                 new_key.access_token = request.query_params.get("access_token", None)
-            else:
+            except (AttributeError, KeyError):
                 new_key.access_token = None
             if hasattr(request, "auth"):
-                if hasattr(request.auth, "application"):
-                    # oauth2 project auth
-                    new_key.project_id = request.auth.application.id
-                else:
-                    # onsite project auth
-                    new_key.project_id = request.auth.id
+                new_key.project_id = request.auth.id
             else:
                 # We do not have an accessing project
                 new_key.project_id = None

--- a/data_import/serializers.py
+++ b/data_import/serializers.py
@@ -16,7 +16,7 @@ class DataFileSerializer(serializers.Serializer):
     def to_representation(self, instance):
         """
         Rewrite the ModelSerializer to_representation to pass request on to the
-        datafile model's private_download_url function for logging purposes when
+        datafile model's download_url function for logging purposes when
         keys are created.
         """
         request = self.context.get("request", None)
@@ -24,7 +24,7 @@ class DataFileSerializer(serializers.Serializer):
         ret["id"] = instance.id
         ret["basename"] = instance.basename
         ret["created"] = instance.created
-        ret["download_url"] = instance.private_download_url(request)
+        ret["download_url"] = instance.download_url(request)
         ret["metadata"] = instance.metadata
         ret["source"] = instance.source
 

--- a/open_humans/templates/member/member-detail-content.html
+++ b/open_humans/templates/member/member-detail-content.html
@@ -72,7 +72,7 @@
                 {{ datafile.basename }}
               </div>
               <div class="col-xs-4 col-md-2 col-md-push-3">
-                <a class="btn btn-default btn-xs" href="{{ datafile.download_url }}" download>
+                <a class="btn btn-default btn-xs" href={% get_download_url data_file %}"" download>
                   Download</a>
               </div>
               <div class="col-xs-11 col-xs-offset-1 col-md-3 col-md-offset-0 col-md-pull-2">

--- a/open_humans/templates/partials/activity-management-your-data.html
+++ b/open_humans/templates/partials/activity-management-your-data.html
@@ -1,6 +1,7 @@
 <hr>
 
 {% load data_import %}
+{% load utilities %}
 
 {% include 'partials/public-sharing-button.html' with public_button_next=request.path %}
 <h2>Your Data</h2>
@@ -14,7 +15,7 @@
         {{ data_file.basename }}
       </div>
       <div class="col-xs-4 col-md-2 col-md-push-3">
-        <a class="btn btn-default btn-xs" href="{{ data_file.download_url }}" download>
+        <a class="btn btn-default btn-xs" href="{% get_download_url data_file %}" download>
           Download</a>
       </div>
       <div class="col-xs-11 col-xs-offset-1 col-md-3 col-md-offset-0 col-md-pull-2">

--- a/open_humans/templatetags/utilities.py
+++ b/open_humans/templatetags/utilities.py
@@ -362,3 +362,11 @@ def project_is_connected(project, user):
     Return True if the given project is connected (joined and authorized).
     """
     return project.is_joined(user)
+
+
+@register.simple_tag(takes_context=True)
+def get_download_url(context, data_file):
+    """
+    Returns the download url
+    """
+    return data_file.download_url(context.request)


### PR DESCRIPTION
## Description
Previously, public data files did not have keys associated with them due to concerns over performance.  Now that the relevant API endpoints have been properly paginated, these concerns have been alleviated. This change enables file download key generations for all files, as each key points to a database entry containing much useful information.

## Related Issue
N/A

## Testing
Automated testing passes
Instrumented with Silk and found no observable difference in performance
Tested API endpoints such as the member-exchange endpoint as well as the "Your Data" section of the Activity page.


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>