### PR TITLE
dynamically display domain

### DIFF
--- a/open_humans/templates/pages/public-data-api.html
+++ b/open_humans/templates/pages/public-data-api.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load static %}
+{% load utilities %}
 
 {% block head_title %}The Public Data API{% endblock %}
 
@@ -34,8 +35,8 @@
 
     <p>
        The base URL for the API is <a
-       href="https://www.openhumans.org/api/public-data/">
-         <code>https://www.openhumans.org/api/public-data/</code></a>.
+       href="{% domain %}/api/public-data/">
+         <code>{% domain %}/api/public-data/</code></a>.
     </p>
 
     <p>
@@ -74,8 +75,8 @@
 
     <p>
       <code><a
-       href="https://www.openhumans.org/api/public-data/?username=madprime&limit=5">
-          https://www.openhumans.org/api/public-data/?username=madprime&limit=5</a>
+       href="{% domain %}/api/public-data/?username=madprime&limit=5">
+          {% domain %}/api/public-data/?username=madprime&limit=5</a>
       </code>
     </p>
 
@@ -86,8 +87,8 @@
 
     <p>
       <code><a
-       href="https://www.openhumans.org/api/public-data/?created_start=2/14/2016&created_end=2/14/2016&source=direct-sharing-139">
-          https://www.openhumans.org/api/public-data/?created_start=2/14/2016&created_end=2/14/2016&source=direct-sharing-139</a>
+       href="{% domain %}/api/public-data/?created_start=2/14/2016&created_end=2/14/2016&source=direct-sharing-139">
+          {% domain %}/api/public-data/?created_start=2/14/2016&created_end=2/14/2016&source=direct-sharing-139</a>
       </code>
     </p>
 
@@ -99,12 +100,12 @@
 
     <ul>
       <li>
-        <a href="https://www.openhumans.org/api/public-data/sources-by-member/">
-          <code>https://www.openhumans.org/api/public-data/sources-by-member/</code></a></li>
+        <a href="{% domain %}/api/public-data/sources-by-member/">
+          <code>{% domain %}/api/public-data/sources-by-member/</code></a></li>
 
       <li>
-        <a href="https://www.openhumans.org/api/public-data/members-by-source/">
-          <code>https://www.openhumans.org/api/public-data/members-by-source/</code></a></li>
+        <a href="{% domain %}/api/public-data/members-by-source/">
+          <code>{% domain %}/api/public-data/members-by-source/</code></a></li>
     </ul>
 
     <h3>Query for a specific data type</h3>
@@ -134,8 +135,8 @@
       You can query the projects endpoint to get information about projects:
     </p>
     <p>
-      <a href="https://www.openhumans.org/api/public-data/projects/">
-      <code>https://www.openhumans.org/api/public-data/projects/</code>
+      <a href="{% domain %}/api/public-data/projects/">
+      <code>{% domain %}/api/public-data/projects/</code>
       </a>
     </p>
     <p>
@@ -143,12 +144,12 @@
     </p>
     <ul>
       <li>
-        <a href="https://www.openhumans.org/api/public-data/projects/?id_label=direct-sharing-176">
-          <code>https://www.openhumans.org/api/public-data/projects/?id_label=direct-sharing-176</code></a></li>
+        <a href="{% domain %}/api/public-data/projects/?id_label=direct-sharing-176">
+          <code>{% domain %}/api/public-data/projects/?id_label=direct-sharing-176</code></a></li>
 
       <li>
-        <a href="https://www.openhumans.org/api/public-data/projects/?id=176">
-          <code>https://www.openhumans.org/api/public-data/projects/?id=176</code></a></li>
+        <a href="{% domain %}/api/public-data/projects/?id=176">
+          <code>{% domain %}/api/public-data/projects/?id=176</code></a></li>
     </ul>
 
     <h3>DataTypes</h3>
@@ -158,16 +159,16 @@
       they may upload. You can see a list of all DataTypes here:
     </p>
     <p>
-      <a href="https://www.openhumans.org/api/public-data/datatypes/">
-      <code>https://www.openhumans.org/api/public-data/datatypes/</code>
+      <a href="{% domain %}/api/public-data/datatypes/">
+      <code>{% domain %}/api/public-data/datatypes/</code>
       </a>
     </p>
     <p>
       You can also filter on a specific project label to see what DataTypes it has registered.
     </p>
     <p>
-      <a href="https://www.openhumans.org/api/public-data/datatypes/?source_project_label=direct-sharing-176">
-      <code>https://www.openhumans.org/api/public-data/datatypes/?source_project_label=direct-sharing-176</code>
+      <a href="{% domain %}/api/public-data/datatypes/?source_project_label=direct-sharing-176">
+      <code>{% domain %}/api/public-data/datatypes/?source_project_label=direct-sharing-176</code>
       </a>
     </p>
   </div>

--- a/open_humans/templatetags/utilities.py
+++ b/open_humans/templatetags/utilities.py
@@ -370,3 +370,11 @@ def get_download_url(context, data_file):
     Returns the download url
     """
     return data_file.download_url(context.request)
+
+
+@register.simple_tag()
+def domain():
+    """
+    For setting the currently set domain in html templates.
+    """
+    return settings.DEFAULT_HTTP_PROTOCOL + "://" + settings.DOMAIN


### PR DESCRIPTION

## Description
This change programatically sets the domain on the api documentation page to the DOMAIN env var.

## Related Issue
N/A

## Testing
loaded page, observed the domain now matched what I have set in my .env file