### PR TITLE
Only log GETs from AWS

### DIFF
--- a/open_humans/management/commands/vacuum_log_bucket.py
+++ b/open_humans/management/commands/vacuum_log_bucket.py
@@ -118,6 +118,8 @@ class Command(BaseCommand):
                 # Filter out things we don't care to log
                 if settings.AWS_STORAGE_BUCKET_NAME in url:
                     continue
+                if "GET" not in str(aws_log_entry.operation):
+                    continue
                 if any(
                     blacklist_item in url for blacklist_item in AWS_LOG_KEY_BLACKLIST
                 ):


### PR DESCRIPTION
## Description
The only interesting datapoint we care about is GET, so we should only log GET operations.

## Related Issue
None

## Testing
Ran against test bucket, observed only GETs were put into DB


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>
