### PR TITLE
Wrapping up datatypes part 1

### DIFF
--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -16,6 +16,25 @@ class DataTypeForm(forms.ModelForm):
         self.editor = kwargs.pop("editor")
         return super().__init__(*args, **kwargs)
 
+    def clean_parent(self):
+        """
+        Verify that the parent is not the object itself nor a descendent.
+        """
+        parent = self.cleaned_data.get("parent")
+        if not parent:
+            return parent
+        if self.instance.id == parent.id:
+            raise forms.ValidationError(
+                "A DataType cannot be assigned to be its own parent."
+            )
+        elif self.instance in parent.all_parents:
+            raise forms.ValidationError(
+                "{0} is not an allowed parent, as it is a descendent of {1}.".format(
+                    parent.name, self.instance.name
+                )
+            )
+        return parent
+
     def clean_name(self):
         """
         Verify that the name is case insensitive unique.

--- a/data_import/serializers.py
+++ b/data_import/serializers.py
@@ -105,9 +105,11 @@ class DataTypeSerializer(serializers.ModelSerializer):
 
     def get_source_projects(self, obj):
         """
-        Get projects associated with a datatype
+        Get approved projects that are registered as potential sources.
         """
-        projects = DataRequestProject.objects.filter(
-            registered_datatypes=obj
-        ).distinct()
+        projects = (
+            DataRequestProject.objects.filter(approved=True)
+            .filter(registered_datatypes=obj)
+            .distinct()
+        )
         return [project.id_label for project in projects]

--- a/data_import/templates/data_import/datatypes-create.html
+++ b/data_import/templates/data_import/datatypes-create.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load bootstrap_tags %}
+{% load utilities %}
 
 {% block main %}
 <h1>Add a DataType</h1>
@@ -13,18 +14,52 @@
     action="{% url 'data-management:datatypes-create' %}" id="add-datatype-form" rel="persist">
     {% csrf_token %}
 
-    {% if form.non_field_errors %}
+    {% if form.errors %}
     <div class="alert alert-danger">
-      <p>
-        {% for error in form.non_field_errors%}
-          <strong>Error:</strong> {{ error }}
+      <h4>Form errors</h4>
+      <ul>
+        {% for error in form.errors %}
+          <li><strong>{{ error }}:</strong> {{ form.errors|lookup:error }}</li>
         {% endfor %}
+      </ul>
       </p>
     </div>
     {% endif %}
 
-    {{ form|as_bootstrap }}
+    <div id="div_id_name" class="form-group">
+      <label for="id_name" class="control-label required-field ">
+        Name
+      </label>
+      <div class="">
+        <input type="text" name="name" maxlength="128" class="form-control"
+            required id="id_name">
+      </div>
+    </div>
 
+    <div id="div_id_parent" class="form-group">
+      <label for="id_parent" class="control-label">
+        Parent
+      </label>
+      <div class="">
+        <select name="parent" class="form-control" id="id_parent">
+          <option value="" selected="">---------</option>
+          {% for item in datatypes_sorted %}
+          <option value="{{ item.datatype.id }}">
+            {{ item.datatype }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    <div id="div_id_description" class="form-group">
+      <label for="id_description" class="control-label required-field ">
+        Description
+      </label>
+      <div class="">
+        <input type="text" name="description" maxlength="512" class="form-control"
+            required id="id_description">
+      </div>
+    </div>
 
     <input id="add-datatype" type="submit"
       value="Add datatype"

--- a/data_import/templates/data_import/datatypes-detail.html
+++ b/data_import/templates/data_import/datatypes-detail.html
@@ -8,7 +8,7 @@
 <p><b>Name: </b> {{ object.name }}</p>
 <p><b>Description:</b> {{ object.description }}</p>
 <p><b>Parent:</b> {% if object.parent %}<a href="{% url 'data-management:datatypes-detail' object.parent.id %}">{{ object.parent.name }}</a>
-  {% else %}None (<a href="{% url 'data-management:datatypes-list' %}">See full list</a>){% endif %}</p>
+  {% else %}None{% endif %} (<a href="{% url 'data-management:datatypes-list' %}">See full list</a>)</p>
 <p><b>Children:</b> {% if not object.children.all %}None{% endif %}</p>
 {% if object.children.all %}
 <ul>

--- a/data_import/templates/data_import/datatypes-update.html
+++ b/data_import/templates/data_import/datatypes-update.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load bootstrap_tags %}
+{% load utilities %}
 
 {% block main %}
 <h1>Update DataType: {{ object.name }}</h1>
@@ -18,14 +19,19 @@
   </tr>
   <tr>
     <th>Parent:</th>
-    <td>{{ object.parent.name }}</td>
+    <td>{% if object.parent %}
+      <a href="{% url 'data-management:datatypes-detail' object.parent.id %}">
+      {{ object.parent.name }}</a>{% else %}
+      None
+      {% endif %}</td>
   </tr>
   <tr>
     <th>Children:</th>
     <td>
       {% if object.children.all %}
       {% for child in object.children.all %}
-      {{ child.name }},
+      <a href="{% url 'data-management:datatypes-detail' child.id %}">
+        {{ child.name }}</a>{% if not forloop.last %},{% endif %}
       {% endfor %}
       {% else %}None{% endif %}
     </td>
@@ -36,18 +42,60 @@
     action="{% url 'data-management:datatypes-update' object.id %}" id="update-datatype-form" rel="persist">
     {% csrf_token %}
 
-    {% if form.non_field_errors %}
+    {% if form.errors %}
     <div class="alert alert-danger">
-      <p>
-        {% for error in form.non_field_errors%}
-          <strong>Error:</strong> {{ error }}
+      <h4>Form errors</h4>
+      <ul>
+        {% for error in form.errors %}
+          <li><strong>{{ error }}:</strong> {{ form.errors|lookup:error }}</li>
         {% endfor %}
+      </ul>
       </p>
     </div>
     {% endif %}
 
-    {{ form|as_bootstrap }}
+    <div id="div_id_name" class="form-group">
+      <label for="id_name" class="control-label required-field ">
+        Name
+      </label>
+      <div class="">
+        <input type="text" name="name" value="{{ object.name }}"
+          maxlength="128" class="form-control" required id="id_name">
+      </div>
+    </div>
 
+    <div id="div_id_parent" class="form-group">
+      <label for="id_parent" class="control-label  ">
+        Parent
+      </label>
+      <div class="">
+        <select name="parent" class="form-control user-success" id="id_parent">
+        <option value="" {% if not object.parent %}selected{% endif %}>---------</option>
+
+          {# Only list potentially valid parents. %}
+          {% for item in datatypes_sorted %}
+            {% ifnotequal item.datatype.id object.id %}
+              {% if object not in item.datatype.all_parents %}
+              <option value="{{ item.datatype.id }}"
+                {% if object.parent %}{% ifequal item.datatype.id object.parent.id %}selected{% endifequal %}{% endif %}>
+                {{ item.datatype }}</option>
+              {% endif %}
+            {% endifnotequal %}
+          {% endfor %}
+
+        </select>
+      </div>
+    </div>
+
+    <div id="div_id_description" class="form-group  ">
+      <label for="id_description" class="control-label required-field ">
+        Description
+      </label>
+      <div class="">
+        <input type="text" name="description" value="Latitude/longitude data" maxlength="512"
+          class="form-control" required id="id_description">
+      </div>
+    </div>
 
     <input id="update-datatype" type="submit"
       value="Update datatype"

--- a/data_import/views.py
+++ b/data_import/views.py
@@ -134,6 +134,18 @@ class AWSDataFileAccessLogView(NeverCacheMixin, ListAPIView):
         return queryset
 
 
+class DataTypesSortedMixin(object):
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        datatypes_sorted = DataType.sorted_by_ancestors()
+        try:
+            max_depth = max([i["depth"] for i in datatypes_sorted])
+        except ValueError:
+            max_depth = 0
+        context.update({"datatypes_sorted": datatypes_sorted, "max_depth": max_depth})
+        return context
+
+
 class DataTypesListView(NeverCacheMixin, TemplateView):
     """
     List all DataTypes.
@@ -172,7 +184,9 @@ class FormEditorMixin(object):
         return kwargs
 
 
-class DataTypesCreateView(PrivateMixin, FormEditorMixin, CreateView):
+class DataTypesCreateView(
+    PrivateMixin, DataTypesSortedMixin, FormEditorMixin, CreateView
+):
     """
     Create a new DataType.
     """
@@ -184,7 +198,9 @@ class DataTypesCreateView(PrivateMixin, FormEditorMixin, CreateView):
         return reverse("data-management:datatypes-list")
 
 
-class DataTypesUpdateView(PrivateMixin, FormEditorMixin, UpdateView):
+class DataTypesUpdateView(
+    PrivateMixin, DataTypesSortedMixin, FormEditorMixin, UpdateView
+):
     """
     Edit a DataType.
     """


### PR DESCRIPTION
## Description
Opening a PR for my work so it can be reviewed, because I might be impaired by opioid drugs.

## Related Issue
Here's a list of TODO items we still want:

 - [x] Dropdown in form for submitting/editing datatypes needs to be ordered
 - [x] Show "see full list" all the time, not just when there's no parent
 - [x] List of DataTypes per project should be filtered on approved projects
 - [ ] ~Project setup description/docs need to include guide for registering data types~
 - [ ] ~'Manage projects' redesigned to have one "manage project" button & name linked to activity page~

_Originally posted by @madprime in https://github.com/OpenHumans/open-humans/pull/1026#issuecomment-481921136_

## Testing
* pass automated tests
* manually testing each item locally