### PR TITLE
Set queryset order for member-exchange endpoint

### DIFF
--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -159,7 +159,7 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
             sources_shared = self.get_sources_shared(self.obj)
             sources_shared.append(self.obj.project.id_label)
             files = all_files.filter(source__in=sources_shared)
-        return files
+        return files.order_by("source").order_by("file").order_by("id")
 
     def list(self, request, *args, **kwargs):
         """

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -159,9 +159,7 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
             sources_shared = self.get_sources_shared(self.obj)
             sources_shared.append(self.obj.project.id_label)
             files = all_files.filter(source__in=sources_shared)
-
-        queryset = sorted(files.order_by("id"), key=lambda f: (f.source, f.basename))
-        return queryset
+        return files.order_by("source", "id")
 
     def list(self, request, *args, **kwargs):
         """

--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -159,7 +159,9 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
             sources_shared = self.get_sources_shared(self.obj)
             sources_shared.append(self.obj.project.id_label)
             files = all_files.filter(source__in=sources_shared)
-        return files.order_by("source").order_by("file").order_by("id")
+
+        queryset = sorted(files.order_by("id"), key=lambda f: (f.source, f.basename))
+        return queryset
 
     def list(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
## Description
It seems that passing an unordered queryset into django's pagination can cause race conditions

## Related Issue
N/A

## Testing
Running Bastian's code produced the incorrect result
Added the ordered_bys and rerunning the code resulted in the problem no longer being present


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>