### PR TITLE
Admin page speedups

### DIFF
--- a/open_humans/admin.py
+++ b/open_humans/admin.py
@@ -10,6 +10,7 @@ class MemberAdmin(admin.ModelAdmin):
     """
 
     raw_id_fields = ("user",)
+    search_fields = ("user__username", "user__email")
 
     def get_queryset(self, request):
         """

--- a/open_humans/admin.py
+++ b/open_humans/admin.py
@@ -3,7 +3,22 @@ from django.contrib.auth.admin import UserAdmin
 
 from .models import Member, User, GrantProject
 
-admin.site.register(Member)
+
+class MemberAdmin(admin.ModelAdmin):
+    """
+    Speed up loading users
+    """
+
+    raw_id_fields = ("user",)
+
+    def get_queryset(self, request):
+        """
+        Go ahead and fetch the user model to speed up the admin page load a bit
+        """
+        return super().get_queryset(request).select_related("user")
+
+
+admin.site.register(Member, MemberAdmin)
 admin.site.register(User, UserAdmin)
 
 

--- a/open_humans/admin.py
+++ b/open_humans/admin.py
@@ -12,12 +12,6 @@ class MemberAdmin(admin.ModelAdmin):
     raw_id_fields = ("user",)
     search_fields = ("user__username", "user__email")
 
-    def get_queryset(self, request):
-        """
-        Go ahead and fetch the user model to speed up the admin page load a bit
-        """
-        return super().get_queryset(request).select_related("user")
-
 
 admin.site.register(Member, MemberAdmin)
 admin.site.register(User, UserAdmin)

--- a/open_humans/member_views.py
+++ b/open_humans/member_views.py
@@ -216,9 +216,9 @@ class MemberJoinedView(PrivateMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        username_access = Q(project__request_username_access=True)
-        request_sources_access = Q(project__requested_sources__isnull=False)
-        all_sources_access = Q(project__all_sources_access=True)
+        username_shared = Q(username_shared=True)
+        granted_sources_none = Q(granted_sources=None)
+        all_sources_shared = Q(all_sources_shared=True)
         project_memberships = (
             DataRequestProjectMember.objects.filter(
                 member=self.request.user.member,
@@ -227,7 +227,7 @@ class MemberJoinedView(PrivateMixin, TemplateView):
                 authorized=True,
                 revoked=False,
             )
-            .filter(username_access | all_sources_access | ~request_sources_access)
+            .filter(username_shared | all_sources_shared | ~granted_sources_none)
             .order_by("project__name")
         )
 

--- a/private_sharing/admin.py
+++ b/private_sharing/admin.py
@@ -10,11 +10,29 @@ class DataRequestProjectMemberAdmin(admin.ModelAdmin):
 
     readonly_fields = ("created",)
     search_fields = ("member__user__username", "project_member_id", "project__name")
+    raw_id_fields = ("member",)
+
+    def get_queryset(self, request):
+        """
+        Go ahead and fetch the member model to speed up the admin page load a bit
+        """
+        return super().get_queryset(request).select_related("member")
+
+
+class DataRequestProjectAdmin(admin.ModelAdmin):
+    """
+    select_related the coordinator field and set to be raw_id
+    """
+
+    raw_id_fields = ("coordinator",)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("coordinator")
 
 
 admin.site.register(models.ProjectDataFile)
-admin.site.register(models.DataRequestProject)
-admin.site.register(models.OAuth2DataRequestProject)
-admin.site.register(models.OnSiteDataRequestProject)
+admin.site.register(models.DataRequestProject, DataRequestProjectAdmin)
+admin.site.register(models.OAuth2DataRequestProject, DataRequestProjectAdmin)
+admin.site.register(models.OnSiteDataRequestProject, DataRequestProjectAdmin)
 admin.site.register(models.DataRequestProjectMember, DataRequestProjectMemberAdmin)
 admin.site.register(models.FeaturedProject)

--- a/private_sharing/admin.py
+++ b/private_sharing/admin.py
@@ -12,22 +12,13 @@ class DataRequestProjectMemberAdmin(admin.ModelAdmin):
     search_fields = ("member__user__username", "project_member_id", "project__name")
     raw_id_fields = ("member",)
 
-    def get_queryset(self, request):
-        """
-        Go ahead and fetch the member model to speed up the admin page load a bit
-        """
-        return super().get_queryset(request).select_related("member")
-
 
 class DataRequestProjectAdmin(admin.ModelAdmin):
     """
-    select_related the coordinator field and set to be raw_id
+    set the coordinator field to be raw_id
     """
 
     raw_id_fields = ("coordinator",)
-
-    def get_queryset(self, request):
-        return super().get_queryset(request).select_related("coordinator")
 
 
 admin.site.register(models.ProjectDataFile)


### PR DESCRIPTION
## Description
Some of the admin pages are slow because they load the full member (or user) list.  This corrects that slowness.

## Related Issue
N/A

## Testing
Verified that DataRequestProject admin pages load much faster now


Signed-off-by: Mairi Dulaney <jdulaney@fedoraproject.org>