### PR TITLE
Some cleanups to avoid legacy approaches.

### DIFF
--- a/open_humans/templates/partials/visible-public-sharing.html
+++ b/open_humans/templates/partials/visible-public-sharing.html
@@ -6,9 +6,9 @@
         <input type="hidden" name="source" value="{{ source }}">
 
         {% if is_visible %}
-          <input type="hidden" name="visible" value="False">
+          <input type="hidden" name="visible_status" value="False">
         {% else %}
-          <input type="hidden" name="visible" value="True">
+          <input type="hidden" name="visible_status" value="True">
         {% endif %}
 
         <button type="submit" class="btn btn-primary btn-xs">

--- a/open_humans/tests.py
+++ b/open_humans/tests.py
@@ -17,7 +17,7 @@ from rest_framework.test import APITestCase
 from mock import patch
 
 from common.testing import BrowserTestCase, get_or_create_user, SmokeTestCase
-from private_sharing.models import toggle_membership_visibility
+from private_sharing.models import DataRequestProject
 
 from .models import Member
 
@@ -342,16 +342,19 @@ class HidePublicMembershipTestCase(APITestCase):
         """
         Tests the public API endpoints.
         """
-        member = UserModel.objects.get(username="bacon")
+        user = UserModel.objects.get(username="bacon")
+        project = DataRequestProject.objects.get(id=1)
+        project_member = project.active_user(user)
 
-        toggle_membership_visibility(member, "direct-sharing-1", "False")
+        project_member.set_visibility(visible_status=False)
         results = self.client.get("/api/public-data/members-by-source/").data["results"]
         result = {}
         for item in results:
             if item["source"] == "direct-sharing-1":
                 result = item
         assert result["usernames"] == []
-        toggle_membership_visibility(member, "direct-sharing-1", "True")
+
+        project_member.set_visibility(visible_status=True)
         results = self.client.get("/api/public-data/members-by-source/").data["results"]
         result = {}
         for item in results:


### PR DESCRIPTION
## Description
While working on a redesign of our activity pages, I ran across some use of legacy "source" labels. This cleans that up with a bit of redesign.