### PR TITLE
Add tests for activity pages

### DIFF
--- a/common/testing.py
+++ b/common/testing.py
@@ -74,10 +74,10 @@ class SmokeTestCase(TestCase):
             )
 
     def test_all_urls_with_login(self):
+        self.assert_login()
+
         for url in self.all_anonymous_urls:
             self.assert_status_code(url)
-
-        self.assert_login()
 
         for url in self.redirect_urls + self.authenticated_urls:
             try:

--- a/open_humans/templates/member/activity-management.html
+++ b/open_humans/templates/member/activity-management.html
@@ -10,7 +10,7 @@
 
 {% block main %}
 
-  {% if user.is_authenticated %}
+  {% if user.is_authenticated and project_member %}
     {% url 'direct-sharing:leave-project' pk=project_member.pk as disconnect_url %}
   {% endif %}
 

--- a/open_humans/templates/partials/activity-info-table.html
+++ b/open_humans/templates/partials/activity-info-table.html
@@ -36,15 +36,6 @@
   </tr>
   {% endif %}
 
-  {% if activity.product_website %}
-  <tr>
-    <th>Product website:</th>
-    <td>
-      <a href="{{ activity.product_website }}">{{ activity.product_website }}</a>
-    </td>
-  </tr>
-  {% endif %}
-
   <tr>
     <th>Stats:</th>
     <td>

--- a/open_humans/templates/partials/activity-management-project-permissions.html
+++ b/open_humans/templates/partials/activity-management-project-permissions.html
@@ -8,12 +8,10 @@
   </li>
   {% endif %}
 
-  {% if permissions.send_messages %}
   <li>
     <b>Permission to send messages.</b> Messages are received as emails,
     but the project does not receive access to the member's email address.
   </li>
-  {% endif %}
 
   {% if permissions.all_sources %}
   <li>

--- a/open_humans/tests.py
+++ b/open_humans/tests.py
@@ -34,6 +34,8 @@ class SmokeTests(SmokeTestCase):
     authenticated_or_anonymous_urls = [
         "/",
         "/about/",
+        "/activity/favorite-trance-tracks/",
+        "/activity/groovy-music/",
         "/api/public-data/?username=beau",
         "/api/public-data/?created_start=2/14/2016&created_end=2/14/2016",
         "/api/public-data/sources-by-member/",


### PR DESCRIPTION
## Description
Following 840358cf it was apparent that we weren't doing automated testing to check that activity pages load. (In this case, server errors were occurring for an AnonymousUser on all activity pages.)

This PR...
1. modifies testing code to add activity pages to testing
2. modifies testing code to fix another issue (`test_all_urls_with_login` wasn't logging in before testing a number of URLs)
3. modifies HTML templates to fix some additional issues discovered through this testing

## Testing
  * confirmed that the new tests would have caught the issue we had
  * automated tests pass
  * locally tested loading activity pages anonymously, not-joined, and joined
