### PR TITLE
Expand private project datafile serialization

### DIFF
--- a/data_import/serializers.py
+++ b/data_import/serializers.py
@@ -1,10 +1,9 @@
 from collections import OrderedDict
-from urllib.parse import urlparse, parse_qs
 
 from django.urls import reverse
 from rest_framework import serializers
 
-from private_sharing.models import DataRequestProject
+from common.utils import full_url
 
 from .models import AWSDataFileAccessLog, DataFile, DataType, NewDataFileAccessLog
 
@@ -55,14 +54,16 @@ class DataFileSerializer(serializers.Serializer):
         Get links to DataType API endpoints for file DataTypes
         """
         return [
-            reverse("api:datatype", kwargs={"pk": dt.id})
+            full_url(reverse("api:datatype", kwargs={"pk": dt.id}))
             for dt in obj.parent_project_data_file.datatypes.all()
         ]
 
     def get_source_project(self, obj):
-        return reverse(
-            "api:project",
-            kwargs={"pk": obj.parent_project_data_file.direct_sharing_project.id},
+        return full_url(
+            reverse(
+                "api:project",
+                kwargs={"pk": obj.parent_project_data_file.direct_sharing_project.id},
+            )
         )
 
 

--- a/data_import/serializers.py
+++ b/data_import/serializers.py
@@ -42,11 +42,28 @@ class DataFileSerializer(serializers.Serializer):
         ret["id"] = instance.id
         ret["basename"] = instance.basename
         ret["created"] = instance.created
+        ret["datatypes"] = self.get_file_datatypes(instance)
         ret["download_url"] = instance.download_url(request)
         ret["metadata"] = instance.metadata
         ret["source"] = instance.source
+        ret["source_project"] = self.get_source_project(instance)
 
         return ret
+
+    def get_file_datatypes(self, obj):
+        """
+        Get links to DataType API endpoints for file DataTypes
+        """
+        return [
+            reverse("api:datatype", kwargs={"pk": dt.id})
+            for dt in obj.parent_project_data_file.datatypes.all()
+        ]
+
+    def get_source_project(self, obj):
+        return reverse(
+            "api:project",
+            kwargs={"pk": obj.parent_project_data_file.direct_sharing_project.id},
+        )
 
 
 class NewDataFileAccessLogSerializer(serializers.ModelSerializer):

--- a/open_humans/serializers.py
+++ b/open_humans/serializers.py
@@ -2,11 +2,12 @@ from collections import OrderedDict
 
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse
 
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
+from common.utils import full_url
 from data_import.models import DataFile
 from private_sharing.models import (
     DataRequestProject,
@@ -43,7 +44,7 @@ class PublicMemberSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_profile_url(obj):
-        return reverse("member-detail", kwargs={"slug": obj.user.username})
+        return full_url(reverse("member-detail", kwargs={"slug": obj.user.username}))
 
 
 class PublicDataFileSerializer(serializers.ModelSerializer):
@@ -73,11 +74,14 @@ class PublicDataFileSerializer(serializers.ModelSerializer):
         Get links to DataType API endpoints for file DataTypes
         """
         return [
-            reverse("api:datatype", kwargs={"pk": dt.id}) for dt in obj.datatypes.all()
+            full_url(reverse("api:datatype", kwargs={"pk": dt.id}))
+            for dt in obj.datatypes.all()
         ]
 
     def get_source_project(self, obj):
-        return reverse("api:project", kwargs={"pk": obj.direct_sharing_project.id})
+        return full_url(
+            reverse("api:project", kwargs={"pk": obj.direct_sharing_project.id})
+        )
 
     def to_representation(self, data):
         """


### PR DESCRIPTION
This adds "datatypes" and "source_project" fields to the datafile serialization in private project APIs, matching the equivalent fields in the [public API datafile serialization](https://www.openhumans.org/api/public/datafiles/).

## Description

As part of making DataTypes useful in the site, I'd like to make them usable by our Jupyter Notebooks servers – but I noticed that the `datatypes` field is _not_ available in private project API datafile serialization. It _is_ available in the public datafile API datafile serialization.

This update adds two new fields to the private project API serialization to match the public API fields: `datatypes` and `source_project`. The second is arguably redundant with `source`, but possibly more useful than the old-style "direct-sharing-" label.

Both fields are providing API paths as identifiers rather than bare IDs. See examples below.

## Examples

Current API behavior returns:
```
{
  'id': 50988,
  'basename': '23andMe-genotyping.txt',
  'created': '2018-05-11T02:46:25.300588Z',
  'download_url': 'https://www.openhumans.org/data-management/datafile-download/50988/?key=32372de0-e355-4c01-8be0-ca117aa51b91',
  'metadata': {
    'tags': ['23andMe', 'genotyping'],
    'description': '23andMe full genotyping data, original format',
    'creation_date': '2018-05-11 02:46:25+00:00'},
  'source': 'direct-sharing-128'
}
```

Updated behavior (new lines bold):
```
{
  'id': 50988,
  'basename': '23andMe-genotyping.txt',
  'created': '2018-05-11T02:46:25.300588Z',
  'datatypes': ['/api/public/datatype/13/'],
  'download_url': 'https://www.openhumans.org/data-management/datafile-download/50988/?key=32372de0-e355-4c01-8be0-ca117aa51b91',
  'metadata': {
    'tags': ['23andMe', 'genotyping'],
    'description': '23andMe full genotyping data, original format',
    'creation_date': '2018-05-11 02:46:25+00:00'},
  'source': 'direct-sharing-128',
  'source_project': '/api/public/project/128/'
}
```

## Testing

Tried this out with a local version of the site. Passed automated tests.