### PR TITLE
Attempted bugfix

### DIFF
--- a/private_sharing/api_views.py
+++ b/private_sharing/api_views.py
@@ -143,8 +143,10 @@ class ProjectMemberExchangeView(NeverCacheMixin, ListAPIView):
         Get the queryset of DataFiles that belong to a member in a project
         """
         self.obj = self.get_object()
-        all_files = DataFile.objects.filter(user=self.obj.member.user).exclude(
-            parent_project_data_file__completed=False
+        all_files = (
+            DataFile.objects.filter(user=self.obj.member.user)
+            .exclude(parent_project_data_file=None)
+            .exclude(parent_project_data_file__completed=False)
         )
 
         if self.obj.all_sources_shared:


### PR DESCRIPTION
Based on speculation that site errors are coming from a race condition
with deleting the DataFile object when a ProjectDataFile is deleted.

Testing:
  * passed automated testing locally
  * ran locally to test manually:
    * confirmed it still seems to work

I wasn't able to reproduce the bug locally, any deletion of a
ProjectDataFile deletes the associated DataFile – thus my
theory of a race condition...