### PR TITLE
Improve auto OAuth2 for permission request changes

### DIFF
--- a/open_humans/views.py
+++ b/open_humans/views.py
@@ -370,30 +370,10 @@ class ActivityManagementView(NeverCacheMixin, LargePanelMixin, TemplateView):
         permissions_changed = False
 
         if "project_id" in self.activity:
-            project_permissions = {
-                "share_username": project.request_username_access,
-                "share_sources": requested_activities,
-                "all_sources": project.all_sources_access,
-                "returned_data_description": project.returned_data_description,
-            }
             if self.activity["is_connected"]:
                 project_member = project.active_user(self.request.user)
-                granted_sources = project_member.granted_sources.all()
-                granted_permissions = {
-                    "share_username": project_member.username_shared,
-                    "share_sources": project_member.granted_sources.all(),
-                    "all_sources": project_member.all_sources_shared,
-                    "returned_data_description": project.returned_data_description,
-                }
-                permissions_changed = not all(
-                    [
-                        granted_permissions[x] == project_permissions[x]
-                        for x in ["share_username", "all_sources"]
-                    ]
-                )
-                gs = set(granted_sources.values_list("id", flat=True))
-                ra = set(requested_activities.values_list("id", flat=True))
-                permissions_changed = permissions_changed or gs.symmetric_difference(ra)
+                granted_permissions = project_member.granted_permissions
+                permissions_changed = project_member.permissions_changed
             if project.no_public_data:
                 public_files = []
 
@@ -412,7 +392,7 @@ class ActivityManagementView(NeverCacheMixin, LargePanelMixin, TemplateView):
                 "source": self.activity["source_name"],
                 "project": project,
                 "project_member": project_member,
-                "project_permissions": project_permissions,
+                "project_permissions": project.permissions,
                 "granted_permissions": granted_permissions,
                 "permissions_changed": permissions_changed,
                 "public_files": public_files,

--- a/private_sharing/views.py
+++ b/private_sharing/views.py
@@ -1,8 +1,12 @@
+import urllib
+
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
+from django.utils.encoding import escape_uri_path
 from django.views.generic import (
     CreateView,
     DetailView,
@@ -340,6 +344,35 @@ class AuthorizeOAuth2ProjectView(
             self.authorize_member(hidden)
 
         return super().form_valid(form)
+
+    def get(self, request, *args, **kwargs):
+        """
+        Override to reload with an updated parameter forcing reauthorization.
+
+        Without this, an existing project member won't be prompted to
+        reauthorize a project that has updated permissions.
+        """
+        project = self.get_object()
+        try:
+            project_member = DataRequestProjectMember.objects.get(
+                project=project,
+                member=request.user.member,
+                joined=True,
+                authorized=True,
+                revoked=False,
+            )
+            if project_member.permissions_changed:
+                if request.GET.get("approval_prompt", "auto") == "auto":
+                    params = request.GET.copy()
+                    params["approval_prompt"] = "force"
+                    reconstructed = "{0}{1}".format(
+                        escape_uri_path(request.path),
+                        "?" + urllib.parse.urlencode(params),
+                    )
+                    return redirect(reconstructed)
+        except DataRequestProjectMember.DoesNotExist:
+            pass
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Description
Avoid "auto authorization" when requested permissions change for an OAuth2 project.

This is done by checking permissions and redirecting to reload the same endpoint with an updated `approval_prompt` parameter, thus prompting re-authorization by the user.

## Related Issue
#1076 

## Testing
  * passed automated testing locally
  * ran locally to test manually:
    * reproduced incorrect auto auth when permissions update
    * confirmed corrected behavior