### PR TITLE
201912 code of conduct update

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,20 +1,78 @@
 # Open Humans Community Code of Conduct
-Adopted Feb 23 2017, adapted from mozilla.org policies, shared under a Creative Commons license (CC-BY-SA 3.0).
-* **Be respectful.** Disagreement is no excuse for poor manners. We will all experience some frustration now and then, but we don’t allow that frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
-* **Try to understand different perspectives.** Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. “Winning” is when different perspectives make our work richer and stronger.
-* **Do not threaten violence.**
-* **Empower others to speak.**
-* **Strive for excellence.** For our products to be great our communities must be healthy and vigorous. Being respectful does not mean papering over disagreements or accepting less than we can do.
-* **Don’t expect to agree with every decision.**
+Updated December 17 2019, adapted from [mozilla.org community guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/), shared under a Creative Commons license (CC-BY-SA 3.0).
 
-## Diversity and Inclusion
-* Open Humans welcomes and encourages participation by everyone. It doesn’t matter how you identify yourself or how others perceive you: we welcome you. We welcome contributions from everyone as long as they interact constructively with our community, including, but not limited to people of varied age, culture, ethnicity, gender, gender-identity, language, race, sexual orientation, geographical location and religious views.
-* Open Humans activities should be inclusive and should support such diversity.
-* Some Open Humans members may identify with activities or organizations that do not support the same inclusion and diversity standards as Open Humans. When this is the case:
-  * (a) support for exclusionary practices must not be carried into Open Humans activities.
-  * (b) support for exclusionary practices in outside activities should not be expressed in Open Humans spaces.
-  * (c) if (a) and (b) are met, other Open Humans members should treat this as a private matter, not an Open Humans issue.
+## About
+
+These guidelines aim to support a community where all people should feel safe to participate, introduce new ideas and inspire others, regardless of:
+
+* Background
+* Family status
+* Gender
+* Gender identity or expression
+* Marital status
+* Sex
+* Sexual orientation
+* Native language
+* Age
+* Ability
+* Race and/or ethnicity
+* National origin
+* Socioeconomic status
+* Religion
+* Geographic location
+* Any other dimension of diversity
+
+## When and how to use these guidelines
+
+These guidelines outline our behavior expectations as members of the Open Humans community in all Open Humans activities, both in-person and online. This includes, but is not limited to:
+
+* Participating in our online communication spaces, including Slack and forums
+* Participating in Open Humans events and in-person spaces
+* Working with other Open Humans members
+* Representing Open Humans at public events and in social media
+
+While these guidelines / code of conduct are specifically aimed at Open Humans work and community, we recognize that it is possible for actions taken outside of our online or in-person spaces to have a deep impact on community health. We welcome discussion in our community about appropriate boundaries.
+
+## Expected behavior
+
+* **Be respectful.** Disagreement is no excuse for poor manners. We will all experience some frustration now and then, but we don’t allow that frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
+
+* **Be inclusive.** Strive to be inclusive in interactions, respecting and facilitating participation whether they are: remote, not native language speakers, coming from a different culture, using pronouns other than “he” or “she”, in a different time zone, or facing other challenges to participate.
+
+* **Value diverse perspectives.** Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. “Winning” is when different perspectives make our work richer and stronger.
+
+## Unacceptable behavior
+
+The following behaviors are considered to be unacceptable under these guidelines.
+
+* **Violence and Threats of Violence** This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people’s personally identifying information (“doxxing”) online.
+
+* **Personal Attacks** It is not okay to insult, demean or belittle others. Discussions should be conducted respectfully and professionally, remaining focused on the issue at hand.
+
+* **Derogatory Language** Hurtful or harmful language related to:
+
+  * Background
+  * Family status
+  * Gender
+  * Gender identity or expression
+  * Marital status
+  * Sex
+  * Sexual orientation
+  * Native language
+  * Age
+  * Ability
+  * Race and/or ethnicity
+  * National origin
+  * Socioeconomic status
+  * Religion
+  * Geographic location
+  * Other attributes
+  * ...is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. If you’re unsure if a word is derogatory, don’t use it. This also includes repeated subtle and/or indirect discrimination; when asked to stop, stop the behavior in question.
+
+* **Unwelcome Sexual Attention or Physical Contact** This includes sexualized comments, sexual jokes or imagery in interactions and communications, as well as sexual advances, touching a person without permission, or physically blocking or intimidating another person. Sexualized images or text that is unnecessary for a discussion is never appropriate.
+
+* **Disruptive Behavior** Sustained disruption is not acceptable. This includes "talking over" or "heckling" individuals, disruptive use of communications channels, and encouraging others to engage in unacceptable behavior.
 
 ## Raising Issues Related to Diversity and Inclusion
 
-If you believe you’re experiencing practices which don’t meet the terms outlined above, please contact us at support@openhumans.org. Intentional efforts to exclude people from Open Humans activities are not acceptable and will be dealt with appropriately. If unintentional exclusion or misunderstandings occur, we will figure out how to make it not happen again.
+If you believe you’re experiencing practices which don’t meet the terms outlined above, please contact us at support@openhumans.org. Alternatively, you may contact members of our leadership team. Intentional efforts to exclude people from Open Humans activities are not acceptable and will be dealt with appropriately. If unintentional exclusion or misunderstandings occur, we will figure out how to make it not happen again.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,6 +41,8 @@ While these guidelines / code of conduct are specifically aimed at Open Humans w
 
 * **Value diverse perspectives.** Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. “Winning” is when different perspectives make our work richer and stronger.
 
+* **Be mindful.** If someone indicates your actions may be unwelcome and contrary to our community guidelines, stop or change what you're doing.
+
 ## Unacceptable behavior
 
 The following behaviors are considered to be unacceptable under these guidelines.
@@ -67,7 +69,7 @@ The following behaviors are considered to be unacceptable under these guidelines
   * Religion
   * Geographic location
   * Other attributes
-  * ...is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. If you’re unsure if a word is derogatory, don’t use it. This also includes repeated subtle and/or indirect discrimination; when asked to stop, stop the behavior in question.
+  * ...is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. This also includes repeated subtle and/or indirect discrimination.
 
 * **Unwelcome Sexual Attention or Physical Contact** This includes sexualized comments, sexual jokes or imagery in interactions and communications, as well as sexual advances, touching a person without permission, or physically blocking or intimidating another person. Sexualized images or text that is unnecessary for a discussion is never appropriate.
 


### PR DESCRIPTION
## Description
Updates to our code of conduct, adapted from the more extensive Mozilla community guidelines.

For the most part this is an expansion. In particular: I'd like to expand our CoC to explicitly describe unacceptable behaviors, rather than hope that they are understood implicitly. I tried to adapt the Mozilla guidelines for concision and relevance.

One substantive difference is removing the assurance that the CoC never applies to behavior occurring outside the community. (It now says that we welcome discussion; this is what Mozilla does.)