### PR TITLE
Bump Django version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ boto3
 brotlipy
 celery==4.3.0
 dj-database-url
-Django==2.2.8
+Django==2.2.9
 django-allauth
 django-appconf
 django-autoslug

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ django-pylibmc==0.6.1
 django-recaptcha==2.0.4
 django-storages==1.7.1
 django-waffle==0.17.0
-django==2.2.8
+django==2.2.9
 djangorestframework==3.9.4
 docopt==0.4.0             # via mailchimp
 docutils==0.14            # via botocore


### PR DESCRIPTION
Based on ASAP upgrade recommendation:
https://www.djangoproject.com/weblog/2019/dec/18/security-releases/