### PR TITLE
Add self-research info page

### DIFF
--- a/open_humans/templates/pages/self-research.html
+++ b/open_humans/templates/pages/self-research.html
@@ -1,0 +1,13 @@
+{% extends 'base-bs4.html' %}
+
+{% block head_title %}Self Research{% endblock %}
+
+{% block main %}
+<p class="text-muted"><i>This page contains extended information about the
+  <a href="https://www.openhumans.org/activity/keating-memorial-self-research/">Keating
+  Memorial Self Research</a> activity run by Open Humans.
+</i></p>
+<div class="embed-responsive embed-responsive-1by1">
+  <iframe class="embed-responsive-item" src="https://docs.google.com/document/d/e/2PACX-1vReHFVpQcby_wBSGvWZ6UztOnN7duRUTTylpAVzHtvLncr6dFXhqZ398NkK6hu4VFyKXVYcPAfYH2RN/pub?embedded=true"></iframe>
+</div>
+{% endblock main %}

--- a/open_humans/urls.py
+++ b/open_humans/urls.py
@@ -255,6 +255,11 @@ urlpatterns = [
         ),
         name="data-processing-activities",
     ),
+    path(
+        "self-research/",
+        TemplateView.as_view(template_name="pages/self-research.html"),
+        name="self-research",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG or settings.TESTING:


### PR DESCRIPTION
There's so many ways to do this. Ugh.

I wanted it to be easy to update the info. I didn't want it to feel confusing going outside the Open Humans site. So, I tried embedding the Google Doc into a webpage, and want to see what others think. It's easy to undo.