### PR TITLE
Add change username form

### DIFF
--- a/open_humans/forms.py
+++ b/open_humans/forms.py
@@ -2,10 +2,12 @@ from captcha.fields import ReCaptchaField
 
 from django import forms
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.urls import reverse
 
+from allauth.account import app_settings as account_settings
 from allauth.account.forms import (
     ChangePasswordForm as AllauthChangePasswordForm,
     LoginForm as AllauthLoginForm,
@@ -17,6 +19,8 @@ from allauth.account.utils import filter_users_by_email
 from allauth.socialaccount.forms import SignupForm as AllauthSocialSignupForm
 
 from .models import Member
+
+User = get_user_model()
 
 
 def _clean_password(child_class, self_instance, password_field_name):
@@ -147,6 +151,23 @@ class MemberChangeNameForm(forms.ModelForm):
     class Meta:  # noqa: D101
         model = Member
         fields = ("name",)
+
+
+class MemberChangeUsernameForm(forms.ModelForm):
+    """
+    A form for editing a member's username.
+    """
+
+    def clean_username(self):
+        username = self.cleaned_data["username"]
+        for validator in account_settings.USERNAME_VALIDATORS:
+            validator(username)
+        return username
+
+    class Meta:  # noqa: D101
+        model = User
+        fields = ("username",)
+        help_texts = {"username": "Letters, number, or underscore only."}
 
 
 class ActivityMessageForm(forms.Form):

--- a/open_humans/member_views.py
+++ b/open_humans/member_views.py
@@ -5,6 +5,7 @@ import arrow
 
 from django.apps import apps
 from django.contrib import messages as django_messages
+from django.contrib.auth import get_user_model
 from django.db.models import Count, Q
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
@@ -30,10 +31,13 @@ from private_sharing.models import (
 from .forms import (
     EmailUserForm,
     MemberChangeNameForm,
+    MemberChangeUsernameForm,
     MemberContactSettingsEditForm,
     MemberProfileEditForm,
 )
 from .models import Member, EmailMetadata
+
+User = get_user_model()
 
 
 class MemberDetailView(DetailView):
@@ -176,6 +180,20 @@ class MemberChangeNameView(PrivateMixin, UpdateView):
 
     def get_object(self, queryset=None):
         return self.request.user.member
+
+
+class MemberChangeUsernameView(PrivateMixin, UpdateView):
+    """
+    Creates an edit view of the current member's name.
+    """
+
+    form_class = MemberChangeUsernameForm
+    model = User
+    template_name = "member/my-member-change-username.html"
+    success_url = reverse_lazy("my-member-settings")
+
+    def get_object(self, queryset=None):
+        return self.request.user
 
 
 class MemberSendConfirmationEmailView(PrivateMixin, RedirectView):

--- a/open_humans/templates/member/my-member-change-name.html
+++ b/open_humans/templates/member/my-member-change-name.html
@@ -23,7 +23,7 @@
     {{ form|as_bootstrap_horizontal:"col-md-4" }}
 
     <span id="helpBlock" class="help-block col-md-offset-4">
-      You may use any name you wish, provided you follow our
+      Your name is publicly visible. You may use any name you wish, provided you follow our
       <a href="{% url 'community_guidelines' %}#naming">Naming Guidelines</a>.
     </span>
 

--- a/open_humans/templates/member/my-member-settings.html
+++ b/open_humans/templates/member/my-member-settings.html
@@ -147,18 +147,11 @@
 
     <div class="col-md-6">
       <p>{{ user.username }}</p>
-
-      <p class="text-muted">
-        Please email <a href="mailto:support@openhumans.org">support@openhumans.org</a>
-        to request a username change.
-      </p>
-
-      {% comment %}
-      <a href="#?next={% url 'my-member-settings' %}"
-      class="btn btn-default btn-sm btn-primary">
-      Change username
+      <a href="{% url 'my-member-change-username' %}?next={% url 'my-member-settings' %}"
+          class="btn btn-sm btn-primary">
+        Change username
       </a>
-      {% endcomment %}
+
     </div>
   </div>
 

--- a/open_humans/urls.py
+++ b/open_humans/urls.py
@@ -204,6 +204,11 @@ urlpatterns = [
         name="my-member-change-name",
     ),
     path(
+        "member/me/change-username/",
+        member_views.MemberChangeUsernameView.as_view(),
+        name="my-member-change-username",
+    ),
+    path(
         "member/me/send-confirmation-email/",
         member_views.MemberSendConfirmationEmailView.as_view(),
         name="my-member-send-confirmation-email",


### PR DESCRIPTION
## Description
Give people a form to change their username themselves. Asking us to change it was a legacy issue.

## Testing
  * passed automated testing locally
  * ran locally to test manually:
    * confirmed username change works
    * confirmed error on existing username
    * confirmed custom validation (error on disallowed characters)
