### PR TITLE
Custom django-waffle middleware to store testing flags

### DIFF
--- a/open_humans/settings.py
+++ b/open_humans/settings.py
@@ -207,7 +207,7 @@ MIDDLEWARE = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "open_humans.middleware.AddMemberMiddleware",
-    "waffle.middleware.WaffleMiddleware",
+    "open_humans.middleware.CustomWaffleMiddleware",
     "django.middleware.cache.FetchFromCacheMiddleware",
 )
 


### PR DESCRIPTION
## Description
This makes django-waffle testing flags "stick" when not used by an initial view or template.

django-waffle has an open issue regarding testing flags not being stored in cookie unless there's some attempt to use them in a view or template: https://github.com/django-waffle/django-waffle/issues/80

While the issue seems to think this isn't solvable without breaking backwards compatibility, it seems like my modification to the middleware should generally work? (It uses the flag customization that was described as an issue.)

So, this seems to work for me, but maybe I'm missing something. (And I might submit this solution as a PR to django-waffle.)

## Testing

* Manually tested that a waffle testing flag is now set in a request/response that previously lost the flag (our login redirect)
* Passed automated testing
