### PR TITLE
Update join button to say "study" if it's a study

### DIFF
--- a/open_humans/templates/partials/activity-panel-info.html
+++ b/open_humans/templates/partials/activity-panel-info.html
@@ -175,7 +175,7 @@
       <p>You have not joined <b>{{ project.name }}</b> yet.</p>
       <div class="d-flex mb-3">
         <div class="d-flex align-items-center pr-3">
-          <a class="btn btn-primary btn-lg" href="{{ project.join_url }}">{{ project.connect_verb|title }}&nbsp;project</a>
+          <a class="btn btn-primary btn-lg" href="{{ project.join_url }}">{{ project.connect_verb|title }}&nbsp;{% if project.is_study %}study{% else %}project{% endif %}</a>
         </div>
         <div class="d-flex align-items-center">
           <div class="reduced text-muted">


### PR DESCRIPTION
## Description
Update "join" button to say "study" instead of "project" if the activity is a study.

## Related Issue
This partially addresses issues raised in #1120.

## Testing

  * passed automated testing locally
  * ran locally to test manually reproduce updated behavior