### PR TITLE
Switching  to avoid leading zeros in future memberID creations

### DIFF
--- a/open_humans/models.py
+++ b/open_humans/models.py
@@ -42,12 +42,14 @@ def get_grant_project_image_upload_path(instance, filename):
 
 def random_member_id():
     """
-    Return a zero-padded string from 00000000 to 99999999 that's not in use by
-    any Member.
+    Return a zero-padded string from 10000000 to 99999999 that's not in use by
+    any Member. Previously was 00000000, but the leading zero was dropped by many
+    programs and caused immense headaches, so switching to avoid the leading zero
+    in member numbers. 
     """
 
     def random_id():
-        return str("{0:08d}").format(random.randint(0, 99_999_999))
+        return str("{0:08d}").format(random.randint(10_000_000, 99_999_999))
 
     member_id = random_id()
 


### PR DESCRIPTION
## Description
Previously memberIDs could be created with 0 in the front. Various programs for data processing drop the 0, and then re-using the project memberIDs back in the command line would cause various errors in pulling or processing the data. Immense headaches have ensued for project administrators and data users. This attempts to remove the leading zeros (although it doesn't solve existing memberIDs with leading zeros) from future projectmemberID creation.


## Testing
Have not tested but used OpenAI Codex to validate the sanity of this potential solution.