### PR TITLE
Modified settings.py file to prepend www.

### DIFF
--- a/open_humans/settings.py
+++ b/open_humans/settings.py
@@ -534,5 +534,6 @@ if ON_HEROKU:
     SECURE_SSL_REDIRECT = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+    PREPEND_WWW = True
 
     django_heroku.settings(locals())


### PR DESCRIPTION
## Description
According to mikespinn some combination of browser configurations, regions, proxies, or VPNs do not resolve the openhumans.org url when accessing it without www.
Modifying the settings.py file by adding the following line of code handles this issue:
PREPEND_WWW = True
Fix #1141 

## History
mikepsinn reported on March 1st that he was not able to reach openhumans.org because the url did not resolve to www.openhumans.org

## Testing
Testing the issue in my own browser did not reproduce this problem on commit 5209d00. I am using Firefox Version 94.0.1 64 Bit.
Testing on localhost prepends www.