### PR TITLE
Disallow URLs in about me text

### DIFF
--- a/open_humans/forms.py
+++ b/open_humans/forms.py
@@ -22,6 +22,8 @@ from allauth.socialaccount.forms import SignupForm as AllauthSocialSignupForm
 
 from .models import Member
 
+import re
+
 User = get_user_model()
 
 
@@ -83,12 +85,23 @@ class MemberSignupForm(AllauthSignupForm):
         fields = "__all__"
 
 
+def contain_no_url(value): 
+  """
+  check that value does not contain a link to a website
+  """
+  regex = "https?"
+  if re.findall(regex, value): 
+    raise forms.ValidationError("Can't contain web-links") 
+
 class MemberProfileEditForm(forms.ModelForm):
     """
     A form for editing a member's profile information.
     """
 
     captcha = ReCaptchaField(widget=ReCaptchaV3)
+    about_me = forms.CharField(
+        validators=[contain_no_url],
+        widget=forms.Textarea)
 
     class Meta:  # noqa: D101
         model = Member

--- a/open_humans/forms.py
+++ b/open_humans/forms.py
@@ -91,7 +91,7 @@ def contain_no_url(value):
   """
   regex = "https?"
   if re.findall(regex, value): 
-    raise forms.ValidationError("Can't contain web-links") 
+    raise forms.ValidationError("'About me' can not contain links.") 
 
 class MemberProfileEditForm(forms.ModelForm):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

So far this feature seems to be used only by spammers, at least in 99.9% of cases, so an easy fix is to not allow URLs in the field. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Testing
<!---
Please list of any testing you have done for this work.

This is not focused on automated tests (although those are nice).
Report anything, from basic "ran the code locally" to a design review.

For example, the following might be reported for a PR fixing a bug in
handling the "title" field a submitted form:

  * passed automated testing locally
  * ran locally to test manually:
    * reproduced bug
    * confirmed corrected behavior
    * tested behavior is as expected when form data is initially
      incorrect and corrected on re-entry
-->
